### PR TITLE
Add explicit github_token to Claude workflows

### DIFF
--- a/.github/workflows/auto-pr-description.yml
+++ b/.github/workflows/auto-pr-description.yml
@@ -26,6 +26,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,6 +25,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

This PR adds explicit `github_token` configuration to the Claude Code GitHub Actions workflows. The `github_token` parameter is now explicitly passed to both the auto-PR description and code review workflows, ensuring proper authentication for GitHub API operations.

## Changes

### Workflow Updates
- **`.github/workflows/auto-pr-description.yml`**: Added `github_token: ${{ secrets.GITHUB_TOKEN }}` to the claude-code-action configuration
- **`.github/workflows/claude-code-review.yml`**: Added `github_token: ${{ secrets.GITHUB_TOKEN }}` to the claude-code-action configuration

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Other (please describe)

## Testing

- The workflows will be tested automatically when this PR is created/updated
- Both workflows should now have proper GitHub API authentication
- No functional changes to the workflow logic - this is a configuration improvement

## Context

This change ensures that the Claude Code action has explicit access to the GitHub token, which may be required for certain GitHub API operations like reading PR details, posting comments, or updating PR descriptions. While GitHub Actions typically provides this token automatically, explicitly passing it is a best practice for clarity and reliability.