### PR TITLE
feat: add dark mode support for rate limit toast

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -76,6 +76,14 @@
   #threads-dismiss-toast {
     color: #fde68a;
   }
+
+  #threads-open-settings-btn {
+    background: #d97706;
+  }
+
+  #threads-open-settings-btn:hover {
+    background: #b45309;
+  }
 }
 
 @keyframes slideInRight {


### PR DESCRIPTION
Improve toast notification readability in dark mode with warm color scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)