### PR TITLE
feat: add hide-new-users toggle and per-location hide filter

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -220,5 +220,17 @@
   },
   "clearing": {
     "message": "Clearing..."
+  },
+  "hideNewUsersLabel": {
+    "message": "Hide New Users"
+  },
+  "hideLocationTitle": {
+    "message": "Click to hide posts from this location"
+  },
+  "unhideLocationTitle": {
+    "message": "Click to unhide posts from this location"
+  },
+  "hideLocationAria": {
+    "message": "Toggle hide location"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -223,5 +223,17 @@
   },
   "clearing": {
     "message": "クリア中..."
+  },
+  "hideNewUsersLabel": {
+    "message": "新規ユーザーを非表示"
+  },
+  "hideLocationTitle": {
+    "message": "クリックしてこの地域の投稿を非表示"
+  },
+  "unhideLocationTitle": {
+    "message": "クリックしてこの地域の投稿を再表示"
+  },
+  "hideLocationAria": {
+    "message": "地域の非表示を切り替え"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -223,5 +223,17 @@
   },
   "clearing": {
     "message": "지우는 중..."
+  },
+  "hideNewUsersLabel": {
+    "message": "신규 사용자 숨기기"
+  },
+  "hideLocationTitle": {
+    "message": "이 지역의 게시물 숨기기"
+  },
+  "unhideLocationTitle": {
+    "message": "이 지역의 게시물 다시 표시"
+  },
+  "hideLocationAria": {
+    "message": "지역 숨기기 전환"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -223,5 +223,17 @@
   },
   "clearing": {
     "message": "清除中..."
+  },
+  "hideNewUsersLabel": {
+    "message": "隐藏新账号"
+  },
+  "hideLocationTitle": {
+    "message": "点击以隐藏此地点的帖子"
+  },
+  "unhideLocationTitle": {
+    "message": "点击以恢复显示此地点的帖子"
+  },
+  "hideLocationAria": {
+    "message": "切换隐藏地点"
   }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -226,5 +226,17 @@
   },
   "clearing": {
     "message": "清除中..."
+  },
+  "hideNewUsersLabel": {
+    "message": "隱藏新帳號"
+  },
+  "hideLocationTitle": {
+    "message": "點擊以隱藏此地點的貼文"
+  },
+  "unhideLocationTitle": {
+    "message": "點擊以恢復顯示此地點的貼文"
+  },
+  "hideLocationAria": {
+    "message": "切換隱藏地點"
   }
 }

--- a/src/content.js
+++ b/src/content.js
@@ -7,6 +7,7 @@ import { fetchProfileByUserId, getUserIdByUsername, updateButtonWithFetchResult 
 import { showRateLimitToast, showLoginRequiredBanner } from './lib/notifications.js';
 import { queueFetch, processFetchQueue, processFollowersFetchQueue } from './lib/queueManager.js';
 import { createFeedVisibilityObserver, createFollowersVisibilityObserver } from './lib/autoFetchObservers.js';
+import { getFilterSettings, shouldHideProfile, hideContainer, unhideAllContainers } from './lib/profileFilter.js';
 import { polyfillCountryFlagEmojis } from 'country-flag-emoji-polyfill';
 
 'use strict';
@@ -308,6 +309,12 @@ function addFetchButtons() {
     // If we have cached data for this user, display badge directly without creating button
     if (profileCache.has(username)) {
       const profileInfo = profileCache.get(username);
+
+      // Hide whole post/user row if it matches the user's filter settings
+      if (await shouldHideProfile(profileInfo)) {
+        hideContainer(postContainer);
+        return;
+      }
 
       if (isUserList) {
         // User-list context: use friendships badge (pill style, positioned right)
@@ -715,6 +722,48 @@ async function updateBadgesForFlagsChange() {
   console.log('[Threads Extractor] Updated all badges for flags change');
 }
 
+/**
+ * Re-evaluate hide filter for all known posts. Used when settings change.
+ * Unhides everything first, then re-hides whatever now matches the filter.
+ */
+async function reapplyHideFilter() {
+  // Reset: un-hide everything we previously hid
+  unhideAllContainers();
+
+  const settings = await getFilterSettings();
+
+  // For posts: walk existing badges and hide their post containers if needed
+  const allBadges = document.querySelectorAll(
+    '.threads-profile-info-badge, .threads-friendships-location-badge'
+  );
+
+  for (const badge of allBadges) {
+    let username = null;
+    const ancestor = badge.closest('[role="article"]') || badge.parentElement?.closest('div');
+    if (ancestor) {
+      const profileLink = ancestor.querySelector('a[href^="/@"]');
+      if (profileLink) {
+        const href = profileLink.getAttribute('href');
+        const match = href.match(/^\/@([\w.]+)/);
+        if (match) username = match[1];
+      }
+    }
+    if (!username || !profileCache.has(username)) continue;
+
+    const profileInfo = profileCache.get(username);
+    if (await shouldHideProfile(profileInfo, settings)) {
+      // Prefer the formal post container; fall back to closest pressable/article ancestor
+      const target =
+        findPostContainer(badge) ||
+        badge.closest('[data-pressable-container="true"]') ||
+        badge.closest('[role="article"]');
+      if (target) hideContainer(target);
+    }
+  }
+
+  console.log('[Threads Extractor] Re-applied hide filter');
+}
+
 // Listen for setting changes from popup
 browserAPI.runtime.onMessage.addListener((message) => {
   if (message.type === 'AUTO_QUERY_CHANGED') {
@@ -734,6 +783,11 @@ browserAPI.runtime.onMessage.addListener((message) => {
     console.log('[Threads Extractor] Custom emojis changed, refreshing badges');
     // Update all existing badges to show new custom emojis
     updateBadgesForFlagsChange();
+  } else if (message.type === 'HIDE_FILTER_CHANGED') {
+    console.log('[Threads Extractor] Hide filter changed, reapplying');
+    reapplyHideFilter();
+    // Also rescan in case new posts can now be hidden as we paginate
+    setTimeout(addFetchButtons, 100);
   }
 });
 

--- a/src/lib/friendshipsUI.js
+++ b/src/lib/friendshipsUI.js
@@ -7,6 +7,7 @@ import { findUsernameContainer } from './domHelpers.js';
 import { isNewUser } from './dateParser.js';
 import { formatLocation } from './locationMapper.js';
 import { fetchProfileByUserId, updateButtonWithFetchResult } from './profileFetcher.js';
+import { shouldHideProfile, hideContainer } from './profileFilter.js';
 
 // Cross-browser compatibility
 const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
@@ -126,12 +127,20 @@ async function injectLocationBadgeIntoUserRow(username, profileInfo) {
   // Find all links to this user's profile
   const profileLinks = document.querySelectorAll(`a[href="/@${username}"]`);
 
+  const filterHit = await shouldHideProfile(profileInfo);
+
   for (const link of profileLinks) {
     // Navigate up to find the user row container
     let userRow = link;
     for (let i = 0; i < 10 && userRow; i++) {
       // Look for the container that has the username
       if (userRow.querySelector && userRow.textContent.includes(username)) {
+        // If filtered out, hide the whole user row instead of inserting a badge
+        if (filterHit) {
+          hideContainer(userRow);
+          return;
+        }
+
         // Check if we already added a badge
         if (userRow.querySelector('.threads-friendships-location-badge')) {
           return;

--- a/src/lib/postUI.js
+++ b/src/lib/postUI.js
@@ -1,6 +1,8 @@
 // Post UI functions for displaying profile info on Threads posts
 import { isNewUser } from './dateParser.js';
 import { formatLocation } from './locationMapper.js';
+import { shouldHideProfile, hideContainer } from './profileFilter.js';
+import { findPostContainer } from './domHelpers.js';
 
 // Cross-browser compatibility
 const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
@@ -16,8 +18,21 @@ export async function displayProfileInfo(profileInfo, profileCache) {
   // Find all fetch buttons for this user
   const postButtons = document.querySelectorAll(`.threads-fetch-btn[data-username="${username}"]`);
 
+  const filterHit = await shouldHideProfile(profileInfo);
+
   // Handle post-style buttons
   for (const btn of postButtons) {
+    // If this profile is filtered out, hide its post container and skip badge insertion
+    if (filterHit) {
+      const container =
+        findPostContainer(btn) ||
+        btn.closest('[data-pressable-container="true"]') ||
+        btn.closest('[role="article"]');
+      if (container) hideContainer(container);
+      btn.style.display = 'none';
+      continue;
+    }
+
     // Check if we already added a badge next to this button
     if (btn.previousElementSibling?.classList?.contains('threads-profile-info-badge')) continue;
 

--- a/src/lib/profileFilter.js
+++ b/src/lib/profileFilter.js
@@ -1,0 +1,80 @@
+/**
+ * Profile filter: decides whether a profile should be hidden in feed / lists
+ * based on user settings (hideNewUsers, hiddenLocations).
+ */
+
+import { isNewUser } from './dateParser.js';
+
+const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
+
+/**
+ * Read current filter settings from storage.
+ * @returns {Promise<{hideNewUsers: boolean, hiddenLocations: Object}>}
+ */
+export async function getFilterSettings() {
+  const { hideNewUsers = false, hiddenLocations = {} } =
+    await browserAPI.storage.local.get(['hideNewUsers', 'hiddenLocations']);
+  return { hideNewUsers, hiddenLocations };
+}
+
+/**
+ * Decide whether a profile should be hidden.
+ * Verified accounts are never hidden by the "new user" rule.
+ *
+ * @param {Object} profileInfo - { joined, location, isVerified, ... }
+ * @param {{hideNewUsers: boolean, hiddenLocations: Object}} [settings]
+ * @returns {Promise<boolean>}
+ */
+export async function shouldHideProfile(profileInfo, settings) {
+  if (!profileInfo) return false;
+  const cfg = settings || (await getFilterSettings());
+
+  if (cfg.hideNewUsers && !profileInfo.isVerified && isNewUser(profileInfo.joined)) {
+    return true;
+  }
+
+  if (profileInfo.location) {
+    const loc = String(profileInfo.location).trim();
+    if (loc && cfg.hiddenLocations && cfg.hiddenLocations[loc]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Hide a container element (post / user row) by collapsing it.
+ * Marks it with a data attribute so we can later un-hide if settings change.
+ *
+ * @param {HTMLElement|null} container
+ */
+export function hideContainer(container) {
+  if (!container || !container.style) return;
+  container.setAttribute('data-threads-hidden', 'true');
+  container.style.display = 'none';
+}
+
+/**
+ * Re-show all containers previously hidden by hideContainer().
+ */
+export function unhideAllContainers() {
+  document.querySelectorAll('[data-threads-hidden="true"]').forEach((el) => {
+    el.removeAttribute('data-threads-hidden');
+    el.style.removeProperty('display');
+  });
+}
+
+/**
+ * Convenience: check + hide. Returns true if the container was hidden.
+ *
+ * @param {Object} profileInfo
+ * @param {HTMLElement|null} container
+ * @param {{hideNewUsers: boolean, hiddenLocations: Object}} [settings]
+ * @returns {Promise<boolean>}
+ */
+export async function hideIfFiltered(profileInfo, container, settings) {
+  const hide = await shouldHideProfile(profileInfo, settings);
+  if (hide) hideContainer(container);
+  return hide;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -237,7 +237,7 @@
 
       .stats {
         display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-columns: 1fr 1fr;
         gap: 10px;
         margin-bottom: 12px;
         background: linear-gradient(
@@ -756,6 +756,46 @@
         display: none;
       }
 
+      .location-hide-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border: none;
+        border-radius: 6px;
+        font-size: 14px;
+        cursor: pointer;
+        transition: all 0.2s;
+        background: var(--bg-overlay-10);
+        opacity: 0.55;
+      }
+
+      .location-hide-btn:hover {
+        background: var(--bg-overlay-20);
+        opacity: 1;
+        transform: scale(1.05);
+      }
+
+      .location-hide-btn.is-active {
+        background: rgba(239, 68, 68, 0.25);
+        opacity: 1;
+      }
+
+      .location-hide-btn.is-active:hover {
+        background: rgba(239, 68, 68, 0.4);
+      }
+
+      .location-stat-item.is-hidden-loc .location-name {
+        text-decoration: line-through;
+        color: var(--text-secondary);
+      }
+
+      .location-stat-item.is-hidden-loc .location-bar-fill {
+        background: var(--text-secondary);
+        opacity: 0.4;
+      }
+
       .btn-reset-emoji:hover {
         background: var(--bg-overlay-20);
         opacity: 1;
@@ -1079,6 +1119,21 @@
                 id="showFlagsToggle"
                 checked
                 aria-label="Toggle country flag display"
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label" data-i18n="hideNewUsersLabel">
+            Hide New Users
+          </div>
+          <div class="toggle-group single">
+            <label class="toggle-switch">
+              <input
+                type="checkbox"
+                id="hideNewUsersToggle"
+                aria-label="Toggle hiding posts from new users"
               />
               <span class="toggle-slider"></span>
             </label>

--- a/src/popup.js
+++ b/src/popup.js
@@ -60,6 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const autoQueryToggle = document.getElementById('autoQueryToggle');
   const autoQueryFollowersToggle = document.getElementById('autoQueryFollowersToggle');
   const showFlagsToggle = document.getElementById('showFlagsToggle');
+  const hideNewUsersToggle = document.getElementById('hideNewUsersToggle');
   const locationFilter = document.getElementById('locationFilter');
   const onboardingLink = document.getElementById('onboardingLink');
   const tabBtns = document.querySelectorAll('.tab-btn');
@@ -129,12 +130,14 @@ document.addEventListener('DOMContentLoaded', () => {
     autoQueryToggle.disabled = true;
     autoQueryFollowersToggle.disabled = true;
     showFlagsToggle.disabled = true;
+    hideNewUsersToggle.disabled = true;
   }
 
   function enableAllToggles() {
     autoQueryToggle.disabled = false;
     autoQueryFollowersToggle.disabled = false;
     showFlagsToggle.disabled = false;
+    hideNewUsersToggle.disabled = false;
   }
 
   // Detect if we should use sheet modal for emoji picker
@@ -277,6 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'autoQueryEnabled',
     'autoQueryFollowersEnabled',
     'showFlags',
+    'hideNewUsers',
     'rateLimitedUntil'
   ]).then((result) => {
     // Check if currently rate limited
@@ -291,6 +295,7 @@ document.addEventListener('DOMContentLoaded', () => {
     autoQueryToggle.checked = result.autoQueryEnabled !== false;
     autoQueryFollowersToggle.checked = result.autoQueryFollowersEnabled === true;
     showFlagsToggle.checked = result.showFlags !== false;
+    hideNewUsersToggle.checked = result.hideNewUsers === true;
   });
 
   // Additional toggle change event listeners
@@ -315,6 +320,19 @@ document.addEventListener('DOMContentLoaded', () => {
           // Content script not loaded yet - that's ok
         });
       }
+    });
+  });
+
+  hideNewUsersToggle.addEventListener('change', () => {
+    const enabled = hideNewUsersToggle.checked;
+    browserAPI.storage.local.set({ hideNewUsers: enabled });
+    // Notify all Threads tabs so they can apply/remove hiding immediately
+    browserAPI.tabs.query({ url: 'https://www.threads.com/*' }).then((tabs) => {
+      tabs.forEach((tab) => {
+        browserAPI.tabs.sendMessage(tab.id, { type: 'HIDE_FILTER_CHANGED' }).catch(() => {
+          // Content script not loaded - ignore
+        });
+      });
     });
   });
 
@@ -830,10 +848,31 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  // Save hidden location toggle, then notify content scripts
+  async function setLocationHidden(location, hidden) {
+    const { hiddenLocations = {} } = await browserAPI.storage.local.get(['hiddenLocations']);
+    if (hidden) {
+      hiddenLocations[location] = true;
+    } else {
+      delete hiddenLocations[location];
+    }
+    await browserAPI.storage.local.set({ hiddenLocations });
+
+    browserAPI.tabs.query({ url: 'https://www.threads.com/*' }).then((tabs) => {
+      tabs.forEach((tab) => {
+        browserAPI.tabs.sendMessage(tab.id, { type: 'HIDE_FILTER_CHANGED' }).catch(() => {
+          // ignore
+        });
+      });
+    });
+  }
+
   // Render location stats
   async function renderLocationStats() {
-    // Get custom emojis
-    const { customLocationEmojis = {} } = await browserAPI.storage.local.get(['customLocationEmojis']);
+    // Get custom emojis and hidden locations
+    const { customLocationEmojis = {}, hiddenLocations = {} } = await browserAPI.storage.local.get(
+      ['customLocationEmojis', 'hiddenLocations']
+    );
 
     const entries = Object.entries(profiles);
 
@@ -943,7 +982,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const customEmoji = customLocationEmojis[location] || '';
 
       const item = document.createElement('div');
-      item.className = 'location-stat-item';
+      const isLocHidden = !!hiddenLocations[location];
+      item.className = 'location-stat-item' + (isLocHidden ? ' is-hidden-loc' : '');
       item.setAttribute('data-location', location);
 
       const locationInfo = document.createElement('div');
@@ -1088,12 +1128,36 @@ document.addEventListener('DOMContentLoaded', () => {
       emojiCustomizer.appendChild(emojiPickerBtn);
       emojiCustomizer.appendChild(resetBtn);
 
+      // Hide-location toggle
+      const hideBtn = document.createElement('button');
+      hideBtn.className = 'location-hide-btn' + (isLocHidden ? ' is-active' : '');
+      hideBtn.textContent = '🚫';
+      hideBtn.setAttribute(
+        'aria-label',
+        `${browserAPI.i18n.getMessage('hideLocationAria') || 'Toggle hide location'} ${location}`
+      );
+      hideBtn.title = isLocHidden
+        ? (browserAPI.i18n.getMessage('unhideLocationTitle') || 'Click to unhide posts from this location')
+        : (browserAPI.i18n.getMessage('hideLocationTitle') || 'Click to hide posts from this location');
+
+      hideBtn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const nowHidden = !item.classList.contains('is-hidden-loc');
+        item.classList.toggle('is-hidden-loc', nowHidden);
+        hideBtn.classList.toggle('is-active', nowHidden);
+        hideBtn.title = nowHidden
+          ? (browserAPI.i18n.getMessage('unhideLocationTitle') || 'Click to unhide posts from this location')
+          : (browserAPI.i18n.getMessage('hideLocationTitle') || 'Click to hide posts from this location');
+        await setLocationHidden(location, nowHidden);
+      });
+
       const countSpan = document.createElement('span');
       countSpan.className = 'location-count';
       countSpan.textContent = count;
 
       item.appendChild(locationInfo);
       item.appendChild(emojiCustomizer);
+      item.appendChild(hideBtn);
       item.appendChild(countSpan);
 
       locationStatsListEl.appendChild(item);


### PR DESCRIPTION
## Summary

Adds two opt-in filters that collapse posts and user rows from accounts the user prefers not to see. Both default to **off** so existing behavior is unchanged.

- **Hide New Users** toggle — hides posts/user rows from accounts that joined within the last 2 months. Verified accounts are exempt.
- **Per-location hide** — every entry in the *Location Stats* tab now has a 🚫 toggle. Tap it to hide all posts whose author lists that location; tap again to unhide.

Hidden containers are collapsed via `display: none` and tagged with `data-threads-hidden="true"` so toggling settings reapplies cleanly without a page reload.

## Implementation notes

- New `src/lib/profileFilter.js` centralizes the decision (`shouldHideProfile`) and the hide/unhide helpers.
- Filtering is applied at every badge insertion site:
  - `content.js` `addFetchButtons` (cached profile path)
  - `src/lib/postUI.js` `displayProfileInfo`
  - `src/lib/friendshipsUI.js` `injectLocationBadgeIntoUserRow`
- A new `HIDE_FILTER_CHANGED` runtime message lets the popup broadcast toggle changes to every open Threads tab. `reapplyHideFilter()` in `content.js` unhides everything and re-evaluates against the current settings + cached profiles.
- Settings live in `chrome.storage.local`:
  - `hideNewUsers: boolean` (default `false`)
  - `hiddenLocations: { [locationName]: true }` (default `{}`)
- Popup stats grid changed from 1×3 to 2×2 to fit the new toggle.
- New i18n keys added in all five locales (zh_TW, zh_CN, en, ja, ko): `hideNewUsersLabel`, `hideLocationTitle`, `unhideLocationTitle`, `hideLocationAria`.

## Test plan

- [x] `npm test` — all 99 tests pass
- [x] `npm run build` — Chrome + Firefox builds succeed
- [x] Loaded `dist/chrome` in Chrome and verified:
  - Toggling *Hide New Users* hides posts from accounts joined within 2 months in the feed
  - Verified accounts are not hidden by the new-users rule
  - 🚫 button in *Location Stats* hides posts from that location across the open Threads tab without a refresh
  - Toggling either setting off restores previously hidden posts
  - Settings persist across popup re-opens