### PR TITLE
build: derive extension version from git tag (single source of truth)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,19 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
+      # Fail fast on a tag the build can't version correctly. The workflow
+      # triggers on any `v*`, but the build resolves the version via a 3-part
+      # `git describe --match` glob — so a short tag like `v1.2` or a prerelease
+      # like `v1.2.3-beta.1` would silently resolve to the PREVIOUS release's
+      # version. Require a plain X.Y.Z (optional 4th part for Chrome) here.
+      - name: Validate release tag is a plain version
+        run: |
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "::error::Release tag 'v$VERSION' is not a plain version. Use vX.Y.Z (no prerelease suffix, at least 3 parts)."
+            exit 1
+          fi
+          echo "✅ Release version: $VERSION"
+
       # Fallback only: with fetch-depth 0 the build reads the tag directly, but
       # keep the manifests patched in case describe ever fails. All four
       # manifests are covered so none can fall back to the 0.0.0 placeholder.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,14 @@ jobs:
       # triggers on any `v*`, but the build resolves the version via a 3-part
       # `git describe --match` glob — so a short tag like `v1.2` or a prerelease
       # like `v1.2.3-beta.1` would silently resolve to the PREVIOUS release's
-      # version. Require a plain X.Y.Z (optional 4th part for Chrome) here.
+      # version. Require exactly X.Y.Z: it's the only shape that resolves end to
+      # end (App Store MARKETING_VERSION allows at most 3 parts) and what every
+      # doc example uses. (EXTENSION_VERSION_RE stays looser — a manifest can
+      # hold a 4th part — but a release *tag* must be 3 parts.)
       - name: Validate release tag is a plain version
         run: |
-          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
-            echo "::error::Release tag 'v$VERSION' is not a plain version. Use vX.Y.Z (no prerelease suffix, at least 3 parts)."
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Release tag 'v$VERSION' is not a plain version. Use vX.Y.Z (exactly three numeric parts, no prerelease suffix)."
             exit 1
           fi
           echo "✅ Release version: $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history + tags so the build can derive the version from the
+          # git tag (esbuild.config.js getGitVersion), not just the jq fallback.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -33,25 +37,27 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
+      # Fallback only: with fetch-depth 0 the build reads the tag directly, but
+      # keep the manifests patched in case describe ever fails. All four
+      # manifests are covered so none can fall back to the 0.0.0 placeholder.
       - name: Update version in manifests
         run: |
-          jq ".version = \"$VERSION\"" src/manifest.json > temp.json && mv temp.json src/manifest.json
-          jq ".version = \"$VERSION\"" src/manifest.firefox.json > temp.json && mv temp.json src/manifest.firefox.json
-          jq ".version = \"$VERSION\"" src/manifest.firefox-direct.json > temp.json && mv temp.json src/manifest.firefox-direct.json
+          for m in manifest.json manifest.firefox.json manifest.firefox-direct.json manifest.safari.json; do
+            jq ".version = \"$VERSION\"" "src/$m" > temp.json && mv temp.json "src/$m"
+          done
 
-      - name: Build Chrome and Firefox AMO version
-        run: |
-          echo "🔨 Building Chrome and Firefox AMO version (no update_url, version ${VERSION})..."
-          npm run build:firefox-amo
+      # package.sh cleans dist/, builds Chrome + Firefox AMO, zips them, and
+      # runs the version guard (--web).
+      - name: Package extensions
+        run: bash scripts/package.sh
 
+      # Built after packaging: package.sh wipes dist/, so this must run later to
+      # leave dist/firefox-direct in place for the signing step below.
       - name: Build Firefox self-hosted version (with update_url)
         if: env.ENABLE_FIREFOX_SIGNING == 'true'
         run: |
           echo "🔨 Building Firefox self-hosted version (different add-on ID, version ${VERSION})..."
           npm run build:firefox-self-hosted
-
-      - name: Package extensions
-        run: bash scripts/package.sh
 
       - name: Validate packaged files exist
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,11 +88,13 @@ Use `browserAPI.storage`, `browserAPI.runtime`, `browserAPI.i18n`, etc.
 
 ### Version Management
 
-**IMPORTANT:** Do NOT manually update version numbers in `src/manifest.json`, `src/manifest.firefox.json`, or `src/manifest.firefox-direct.json` during development.
+**The git tag is the single source of truth for the version.** Do NOT hand-edit version numbers anywhere — not in `src/manifest*.json`, not in the Xcode `MARKETING_VERSION`. The `version` field in `src/manifest*.json` is a `0.0.0` placeholder; the build overwrites it from the git tag (see `resolveManifestVersion()` in `esbuild.config.js`).
 
-- **Development builds** (`npm run build:watch`): Automatically uses git tag version + 1 (e.g., if latest tag is `v0.3.7`, dev build shows `0.3.8`)
-- **Production builds** (`npm run build`): Uses the version from source manifests
-- **Release workflow**: Only update manifest versions when creating a release tag
+- **Production builds** (`npm run build`): Uses the latest git tag verbatim (e.g. tag `v1.0.6` → version `1.0.6`).
+- **Development builds** (`npm run build:watch`): Uses git tag + 1 as a next-version preview (e.g. tag `v1.0.6` → `1.0.7`).
+- **No tag reachable**: Falls back to the manifest's own value (e.g. a shallow CI checkout, where `release.yml` has already injected the tag via `jq`).
+
+**Releasing:** tag and push (`git tag vX.Y.Z && git push origin vX.Y.Z`). Chrome/Firefox are built & released automatically by `.github/workflows/release.yml`. For the Safari/iOS App Store build, follow the checklist in [docs/SAFARI_WORKFLOW.md](docs/SAFARI_WORKFLOW.md) — `npm run set:safari-version` sets the Xcode `MARKETING_VERSION` from the tag, and `npm run check:versions` verifies everything agrees.
 
 ### Building the Extension
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,9 @@ Use `browserAPI.storage`, `browserAPI.runtime`, `browserAPI.i18n`, etc.
 
 - **Production builds** (`npm run build`): Uses the latest git tag verbatim (e.g. tag `v1.0.6` → version `1.0.6`).
 - **Development builds** (`npm run build:watch`): Uses git tag + 1 as a next-version preview (e.g. tag `v1.0.6` → `1.0.7`).
-- **No tag reachable**: Falls back to the manifest's own value (e.g. a shallow CI checkout, where `release.yml` has already injected the tag via `jq`).
+- **No valid tag reachable**: falls back to the manifest's value only if it's a valid version (e.g. a shallow CI checkout where `release.yml` injected the tag via `jq`). A production build otherwise **fails** rather than shipping the `0.0.0` placeholder or an invalid version.
 
-**Releasing:** tag and push (`git tag vX.Y.Z && git push origin vX.Y.Z`). Chrome/Firefox are built & released automatically by `.github/workflows/release.yml`. For the Safari/iOS App Store build, follow the checklist in [docs/SAFARI_WORKFLOW.md](docs/SAFARI_WORKFLOW.md) — `npm run set:safari-version` sets the Xcode `MARKETING_VERSION` from the tag, and `npm run check:versions` verifies everything agrees.
+**Releasing:** Chrome/Firefox are built & released automatically by `.github/workflows/release.yml` when you push a `vX.Y.Z` tag. **For the Safari/iOS App Store build, don't just tag-and-push** — follow the verify-before-push checklist in [docs/SAFARI_WORKFLOW.md](docs/SAFARI_WORKFLOW.md) (`set:safari-version X.Y.Z` → commit → tag locally → `build` + `check:versions` → push last → Xcode archive), so the tagged commit already carries the matching `MARKETING_VERSION` and nothing ships before the versions are verified.
 
 ### Building the Extension
 

--- a/docs/SAFARI_WORKFLOW.md
+++ b/docs/SAFARI_WORKFLOW.md
@@ -1,5 +1,17 @@
 # Safari Development Workflow
 
+There are **two separate modes** — don't mix them up:
+
+1. **Develop & test** (most of the time): edit code → `npm run build` → Run in
+   Xcode on the Simulator or a real iPhone. **No git tag, no version steps** —
+   build and run as often as you like. Version numbers are irrelevant here.
+2. **Release to the App Store** (only when shipping): decide the version, sync it
+   from a git tag, verify, then archive & upload. See
+   [Releasing to the App Store](#releasing-to-the-app-store-ios--macos).
+
+The version ceremony (`set:safari-version` / tag / `check:versions`) applies
+**only** to the App Store archive+upload — never to on-device test builds.
+
 ## One-Time Setup
 
 ```bash
@@ -52,6 +64,13 @@ npm run build:watch
 # No need to manually run npm build
 ```
 
+### Testing on a real iPhone
+
+Connect the iPhone, select it as the Xcode run destination, and Run (Cmd+R) —
+same as the Simulator. **No version steps and no git tag are needed**; the popup
+just shows whatever the latest version tag is (or `tag + 1` in watch mode). Test
+freely, then do the version ceremony only when you're ready to ship.
+
 ## Releasing to the App Store (iOS + macOS)
 
 > **You never hand-edit version numbers.** Both the extension version (shown in
@@ -59,31 +78,46 @@ npm run build:watch
 > derived from the **git tag**. Editing `src/manifest*.json` or `MARKETING_VERSION`
 > by hand is what caused past drift (popup stuck at 0.3.7 while Apple saw 1.0.6).
 
+**Order matters.** Pushing the tag immediately triggers the Chrome/Firefox
+release workflow and publishes a public GitHub Release — that half can't be
+un-shipped. So **verify everything locally first, and push the tag last.**
+Because `project.pbxproj` is committed, the version bump must also land *before*
+the tag points at it.
+
 Copy-paste checklist to ship version `X.Y.Z`:
 
 ```bash
-# 1. Tag the release — this is the single source of truth.
-#    (Also triggers the Chrome/Firefox release workflow via GitHub Actions.)
-git tag vX.Y.Z
-git push origin vX.Y.Z
+# 1. Set the Safari app version explicitly (no tag needed yet — this is what
+#    lets the version bump be committed BEFORE the tag exists).
+npm run set:safari-version X.Y.Z   # sets Xcode MARKETING_VERSION (agvtool)
 
-# 2. Sync the Safari app version from the tag, then rebuild the extension.
-npm run set:safari-version   # sets Xcode MARKETING_VERSION from the latest tag (agvtool)
-npm run build                # rebuilds dist/safari/ so the popup version == tag
-
-# 3. Verify every version source agrees with the tag. Fix before continuing.
-npm run check:versions
-
-# 4. Commit the version bump — project.pbxproj IS tracked in git.
+# 2. Commit the bump so the tag (next step) points at a commit that has it.
+#    project.pbxproj IS tracked in git.
 git add "dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj"
 git commit -m "chore: bump Safari MARKETING_VERSION to X.Y.Z"
 
-# 5. Archive & upload in Xcode:
+# 3. Tag that commit LOCALLY — do NOT push yet. The extension build reads the
+#    version from this tag.
+git tag vX.Y.Z
+
+# 4. Build from the tag, then verify everything agrees — BEFORE anything ships.
+npm run build            # dist/safari/manifest.json version == X.Y.Z
+npm run check:versions   # tag / MARKETING_VERSION / dist/* all == X.Y.Z
+
+# 5. Green? Push the tag. This ships Chrome/Firefox and publishes a public
+#    GitHub Release — the irreversible step, done last on purpose.
+git push origin vX.Y.Z
+
+# 6. Archive & upload the Safari/iOS app in Xcode:
 npm run open:safari
 #    - Select the iOS App (or macOS App) scheme
 #    - Set the run destination to "Any iOS Device (arm64)"
 #    - Product → Archive → Distribute App → App Store Connect
 ```
+
+If `check:versions` (step 4) fails, fix it and re-run — nothing has shipped yet
+because the tag is still local. If you need to abandon the version, delete the
+local tag (`git tag -d vX.Y.Z`) before it's pushed.
 
 **Two version numbers, both from the tag automatically:**
 
@@ -107,7 +141,7 @@ number. Bump only the build number (not the version) with:
 | `npm run build:watch` | Development mode (auto-rebuild) | Fast |
 | `npm run setup:safari` | First time / project corrupted | Slow (20s) |
 | `npm run open:safari` | Open Xcode project | Instant |
-| `npm run set:safari-version` | Before App Store archive (sets version from git tag) | Instant |
+| `npm run set:safari-version X.Y.Z` | Before App Store archive (sets `MARKETING_VERSION`) | Instant |
 | `npm run check:versions` | Before release (verify versions match the tag) | Instant |
 
 ## How It Works
@@ -143,6 +177,10 @@ npm run setup:safari
 npm run open:safari
 # Reconfigure signing for each target
 ```
+> ⚠️ `npm run setup:safari` runs the converter with `--force` and regenerates
+> `project.pbxproj` wholesale, resetting `MARKETING_VERSION` (and signing). After
+> re-running it, re-apply the version with `npm run set:safari-version X.Y.Z`
+> before archiving.
 
 **Q: Want to test production build**
 ```bash

--- a/docs/SAFARI_WORKFLOW.md
+++ b/docs/SAFARI_WORKFLOW.md
@@ -52,6 +52,53 @@ npm run build:watch
 # No need to manually run npm build
 ```
 
+## Releasing to the App Store (iOS + macOS)
+
+> **You never hand-edit version numbers.** Both the extension version (shown in
+> the popup) and the app's `MARKETING_VERSION` (shown in App Store Connect) are
+> derived from the **git tag**. Editing `src/manifest*.json` or `MARKETING_VERSION`
+> by hand is what caused past drift (popup stuck at 0.3.7 while Apple saw 1.0.6).
+
+Copy-paste checklist to ship version `X.Y.Z`:
+
+```bash
+# 1. Tag the release — this is the single source of truth.
+#    (Also triggers the Chrome/Firefox release workflow via GitHub Actions.)
+git tag vX.Y.Z
+git push origin vX.Y.Z
+
+# 2. Sync the Safari app version from the tag, then rebuild the extension.
+npm run set:safari-version   # sets Xcode MARKETING_VERSION from the latest tag (agvtool)
+npm run build                # rebuilds dist/safari/ so the popup version == tag
+
+# 3. Verify every version source agrees with the tag. Fix before continuing.
+npm run check:versions
+
+# 4. Commit the version bump — project.pbxproj IS tracked in git.
+git add "dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj"
+git commit -m "chore: bump Safari MARKETING_VERSION to X.Y.Z"
+
+# 5. Archive & upload in Xcode:
+npm run open:safari
+#    - Select the iOS App (or macOS App) scheme
+#    - Set the run destination to "Any iOS Device (arm64)"
+#    - Product → Archive → Distribute App → App Store Connect
+```
+
+**Two version numbers, both from the tag automatically:**
+
+| Number | Where users see it | Set by |
+|--------|--------------------|--------|
+| Extension manifest `version` | Extension popup (`v1.0.6`) | `npm run build` |
+| App `MARKETING_VERSION` | App Store Connect / Apple | `npm run set:safari-version` |
+
+**Re-uploading the same version?** App Store Connect rejects a duplicate build
+number. Bump only the build number (not the version) with:
+
+```bash
+( cd "dist-safari/safari-project/Lee-Su-Sui" && xcrun agvtool next-version -all )
+```
+
 ## Commands Reference
 
 | Command | When to Use | Speed |
@@ -60,6 +107,8 @@ npm run build:watch
 | `npm run build:watch` | Development mode (auto-rebuild) | Fast |
 | `npm run setup:safari` | First time / project corrupted | Slow (20s) |
 | `npm run open:safari` | Open Xcode project | Instant |
+| `npm run set:safari-version` | Before App Store archive (sets version from git tag) | Instant |
+| `npm run check:versions` | Before release (verify versions match the tag) | Instant |
 
 ## How It Works
 
@@ -115,5 +164,10 @@ npm run build
 
 ❌ **DON'T:**
 - Run `npm run setup:safari` for every change
-- Edit files in `dist/safari/` directly (they get overwritten)
-- Commit `dist/` or `dist-safari/` to git (they're gitignored)
+- Edit files in `dist/safari/` directly (they get overwritten by `npm run build`)
+- Hand-edit `MARKETING_VERSION` or `src/manifest*.json` versions — use the git tag + `npm run set:safari-version`
+
+> **Note on what's committed:** `dist/` is gitignored (pure build output).
+> `dist-safari/` is **partially tracked** — the Xcode project (`project.pbxproj`,
+> assets, Swift sources) IS committed; only `build/`, `DerivedData/`, and
+> `xcuserdata/` are ignored. So a `MARKETING_VERSION` bump must be committed.

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,6 +1,6 @@
 import * as esbuild from 'esbuild';
 import { copyFile, mkdir, cp, readFile, writeFile } from 'fs/promises';
-import { getGitVersion, incrementVersion, PLACEHOLDER_VERSION } from './scripts/lib/version.js';
+import { getGitVersion, incrementVersion, isValidExtensionVersion, PLACEHOLDER_VERSION } from './scripts/lib/version.js';
 
 const isWatch = process.argv.includes('--watch');
 const isDev = isWatch || process.env.NODE_ENV === 'development';
@@ -25,15 +25,26 @@ function resolveManifestVersion(manifestVersion, label) {
   const gitVersion = getGitVersion();
   const base = gitVersion || manifestVersion;
 
-  // Never ship the placeholder. In production, a missing tag means the version
-  // is unknown — fail loudly rather than writing 0.0.0 into a store artifact.
-  // Dev/watch is allowed through (0.0.1) so a tagless clone stays buildable.
-  if (!isDev && base === PLACEHOLDER_VERSION) {
-    throw new Error(
-      `Cannot resolve a real version for "${label}": no semver git tag is reachable ` +
-      `and src/manifest is the ${PLACEHOLDER_VERSION} placeholder. ` +
-      `Run "git fetch --tags" (or tag the release) before a production build.`,
-    );
+  // Never ship a bad version. `getGitVersion` is already validated, but `base`
+  // can fall back to the manifest value — which may be the placeholder (no tag)
+  // or an invalid version jq-injected from a non-semver tag (e.g. a prerelease).
+  // In production, fail loudly rather than writing either into a store artifact;
+  // dev/watch is allowed through (0.0.1) so a tagless clone stays buildable.
+  if (!isDev) {
+    if (base === PLACEHOLDER_VERSION) {
+      throw new Error(
+        `Cannot resolve a real version for "${label}": no semver git tag is reachable ` +
+        `and src/manifest is the ${PLACEHOLDER_VERSION} placeholder. ` +
+        `Run "git fetch --tags" (or tag the release) before a production build.`,
+      );
+    }
+    if (!isValidExtensionVersion(base)) {
+      throw new Error(
+        `Cannot resolve a valid version for "${label}": "${base}" ` +
+        `(from ${gitVersion ? 'the git tag' : 'src/manifest'}) is not a valid extension version. ` +
+        `Tag the release with a plain version like vX.Y.Z (no prerelease suffix).`,
+      );
+    }
   }
 
   const version = isDev ? incrementVersion(base) : base;

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -9,21 +9,47 @@ const isDev = isWatch || process.env.NODE_ENV === 'development';
 const FIREFOX_BUILD_TYPE = process.env.FIREFOX_BUILD_TYPE; // 'amo' or 'self-hosted'
 
 // Get version from git tags (supports both annotated and lightweight tags)
+// Placeholder written in src/manifest*.json — the real version is injected at
+// build time from the git tag. Must never reach a shipped artifact.
+const PLACEHOLDER_VERSION = '0.0.0';
+
+// A Chrome MV3 version: 1–4 dot-separated integers.
+const SEMVER_RE = /^\d+(\.\d+){1,3}$/;
+
+let cachedGitVersion;
+
+// Latest semver-shaped git tag (e.g. "v1.0.6" -> "1.0.6"), or null when none.
+// Memoized so every manifest in one build agrees and we spawn `git` once.
 function getGitVersion() {
+  if (cachedGitVersion === undefined) cachedGitVersion = computeGitVersion();
+  return cachedGitVersion;
+}
+
+function computeGitVersion() {
+  let tag;
   try {
-    // Get the latest git tag (e.g., "v0.3.7" or "0.3.7")
-    const tag = execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim();
-    // Remove 'v' prefix if present
-    return tag.startsWith('v') ? tag.slice(1) : tag;
+    // --match restricts to version tags, so a stray tag like "ios-1.0.6" or
+    // "nightly" is never picked up as the version.
+    tag = execSync("git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*'", {
+      encoding: 'utf-8',
+    }).trim();
   } catch (error) {
     const errorMessage = error.message || String(error);
-    if (errorMessage.includes('No names found') || errorMessage.includes('No tags')) {
-      console.warn('⚠️  No git tags found, using manifest version for dev build');
+    if (/No names found|No tags|cannot describe/.test(errorMessage)) {
+      console.warn('⚠️  No matching git version tag found; falling back to manifest version');
     } else {
       console.warn('⚠️  Could not get git version:', errorMessage.split('\n')[0]);
     }
     return null;
   }
+  // Remove 'v' prefix if present, then validate — a prerelease tag like
+  // "v1.1.0-beta.1" passes the glob but is not a valid manifest version.
+  const version = tag.startsWith('v') ? tag.slice(1) : tag;
+  if (!SEMVER_RE.test(version)) {
+    console.warn(`⚠️  Ignoring non-semver git tag "${tag}"`);
+    return null;
+  }
+  return version;
 }
 
 // Increment the patch version (e.g., "0.3.7" -> "0.3.8")
@@ -54,6 +80,18 @@ function incrementVersion(version) {
 function resolveManifestVersion(manifestVersion, label) {
   const gitVersion = getGitVersion();
   const base = gitVersion || manifestVersion;
+
+  // Never ship the placeholder. In production, a missing tag means the version
+  // is unknown — fail loudly rather than writing 0.0.0 into a store artifact.
+  // Dev/watch is allowed through (0.0.1) so a tagless clone stays buildable.
+  if (!isDev && base === PLACEHOLDER_VERSION) {
+    throw new Error(
+      `Cannot resolve a real version for "${label}": no semver git tag is reachable ` +
+      `and src/manifest is the ${PLACEHOLDER_VERSION} placeholder. ` +
+      `Run "git fetch --tags" (or tag the release) before a production build.`,
+    );
+  }
+
   const version = isDev ? incrementVersion(base) : base;
   const source = gitVersion ? `git tag ${gitVersion}` : `manifest ${manifestVersion} (no git tag)`;
   const arrow = version === base ? '' : ` → ${version}`;

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -42,6 +42,25 @@ function incrementVersion(version) {
   return parts.join('.');
 }
 
+// Resolve the version to write into a built manifest.
+//
+// Single source of truth is the latest git tag (e.g. "v1.0.6"):
+//   - Production builds use the tag verbatim  → shipped version === git tag
+//   - Dev/watch builds use tag + 1            → a "next version" preview
+//
+// The `version` field in src/manifest*.json is NOT a source of truth; it is
+// only a fallback for when no git tag is reachable (e.g. a shallow CI checkout
+// without tags, where release.yml has already injected the tag via jq).
+function resolveManifestVersion(manifestVersion, label) {
+  const gitVersion = getGitVersion();
+  const base = gitVersion || manifestVersion;
+  const version = isDev ? incrementVersion(base) : base;
+  const source = gitVersion ? `git tag ${gitVersion}` : `manifest ${manifestVersion} (no git tag)`;
+  const arrow = version === base ? '' : ` → ${version}`;
+  console.log(`📦 ${label}: ${isDev ? 'Dev' : 'Prod'} build using ${source}${arrow}`);
+  return version;
+}
+
 // Build JavaScript bundles (shared between Chrome and Firefox)
 const buildOptions = {
   entryPoints: [
@@ -105,20 +124,7 @@ async function copyStaticFilesForBrowser(browser) {
   const manifestContent = await readFile(sourceManifest, 'utf-8');
   const manifest = JSON.parse(manifestContent);
 
-  // In development, use git tag version + 1 (e.g., "0.3.7" -> "0.3.8")
-  if (isDev) {
-    const gitVersion = getGitVersion();
-    if (gitVersion) {
-      const newVersion = incrementVersion(gitVersion);
-      console.log(`📦 ${browser}: Dev build using git tag ${gitVersion} → ${newVersion}`);
-      manifest.version = newVersion;
-    } else {
-      const oldVersion = manifest.version;
-      const newVersion = incrementVersion(oldVersion);
-      console.log(`📦 ${browser}: Dev build using manifest version ${oldVersion} → ${newVersion}`);
-      manifest.version = newVersion;
-    }
-  }
+  manifest.version = resolveManifestVersion(manifest.version, browser);
 
   await writeFile(`${distDir}/manifest.json`, JSON.stringify(manifest, null, 2));
 
@@ -163,20 +169,7 @@ async function copyStaticFilesForSafari() {
   const manifestContent = await readFile('src/manifest.safari.json', 'utf-8');
   const manifest = JSON.parse(manifestContent);
 
-  // In development, use git tag version + 1
-  if (isDev) {
-    const gitVersion = getGitVersion();
-    if (gitVersion) {
-      const newVersion = incrementVersion(gitVersion);
-      console.log(`📦 safari: Dev build using git tag ${gitVersion} → ${newVersion}`);
-      manifest.version = newVersion;
-    } else {
-      const oldVersion = manifest.version;
-      const newVersion = incrementVersion(oldVersion);
-      console.log(`📦 safari: Dev build using manifest version ${oldVersion} → ${newVersion}`);
-      manifest.version = newVersion;
-    }
-  }
+  manifest.version = resolveManifestVersion(manifest.version, 'safari');
 
   await writeFile(`${distDir}/manifest.json`, JSON.stringify(manifest, null, 2));
 

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,6 +1,6 @@
 import * as esbuild from 'esbuild';
 import { copyFile, mkdir, cp, readFile, writeFile } from 'fs/promises';
-import { execSync } from 'child_process';
+import { getGitVersion, incrementVersion, PLACEHOLDER_VERSION } from './scripts/lib/version.js';
 
 const isWatch = process.argv.includes('--watch');
 const isDev = isWatch || process.env.NODE_ENV === 'development';
@@ -8,65 +8,9 @@ const isDev = isWatch || process.env.NODE_ENV === 'development';
 // Build configuration for Firefox variants
 const FIREFOX_BUILD_TYPE = process.env.FIREFOX_BUILD_TYPE; // 'amo' or 'self-hosted'
 
-// Get version from git tags (supports both annotated and lightweight tags)
-// Placeholder written in src/manifest*.json — the real version is injected at
-// build time from the git tag. Must never reach a shipped artifact.
-const PLACEHOLDER_VERSION = '0.0.0';
-
-// A Chrome MV3 version: 1–4 dot-separated integers.
-const SEMVER_RE = /^\d+(\.\d+){1,3}$/;
-
-let cachedGitVersion;
-
-// Latest semver-shaped git tag (e.g. "v1.0.6" -> "1.0.6"), or null when none.
-// Memoized so every manifest in one build agrees and we spawn `git` once.
-function getGitVersion() {
-  if (cachedGitVersion === undefined) cachedGitVersion = computeGitVersion();
-  return cachedGitVersion;
-}
-
-function computeGitVersion() {
-  let tag;
-  try {
-    // --match restricts to version tags, so a stray tag like "ios-1.0.6" or
-    // "nightly" is never picked up as the version.
-    tag = execSync("git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*'", {
-      encoding: 'utf-8',
-    }).trim();
-  } catch (error) {
-    const errorMessage = error.message || String(error);
-    if (/No names found|No tags|cannot describe/.test(errorMessage)) {
-      console.warn('⚠️  No matching git version tag found; falling back to manifest version');
-    } else {
-      console.warn('⚠️  Could not get git version:', errorMessage.split('\n')[0]);
-    }
-    return null;
-  }
-  // Remove 'v' prefix if present, then validate — a prerelease tag like
-  // "v1.1.0-beta.1" passes the glob but is not a valid manifest version.
-  const version = tag.startsWith('v') ? tag.slice(1) : tag;
-  if (!SEMVER_RE.test(version)) {
-    console.warn(`⚠️  Ignoring non-semver git tag "${tag}"`);
-    return null;
-  }
-  return version;
-}
-
-// Increment the patch version (e.g., "0.3.7" -> "0.3.8")
-function incrementVersion(version) {
-  const parts = version.split('.');
-  if (parts.length < 3) {
-    throw new Error(`Invalid version format "${version}". Expected semver format (X.Y.Z)`);
-  }
-
-  const patchNum = Number(parts[2]);
-  if (isNaN(patchNum)) {
-    throw new Error(`Invalid patch version "${parts[2]}" in version "${version}". Must be a number`);
-  }
-
-  parts[2] = String(patchNum + 1);
-  return parts.join('.');
-}
+// Version resolution (getGitVersion / incrementVersion / PLACEHOLDER_VERSION)
+// lives in scripts/lib/version.js so the build and the release guard share one
+// set of rules — see the import above.
 
 // Resolve the version to write into a built manifest.
 //

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -39,9 +39,12 @@ function resolveManifestVersion(manifestVersion, label) {
       );
     }
     if (!isValidExtensionVersion(base)) {
+      // Only reachable when gitVersion is null (a non-null one is already
+      // validated by getGitVersion), so `base` is always the src/manifest value
+      // here — typically a non-semver tag jq-injected by release.yml.
       throw new Error(
-        `Cannot resolve a valid version for "${label}": "${base}" ` +
-        `(from ${gitVersion ? 'the git tag' : 'src/manifest'}) is not a valid extension version. ` +
+        `Cannot resolve a valid version for "${label}": "${base}" (from src/manifest) ` +
+        `is not a valid extension version. ` +
         `Tag the release with a plain version like vX.Y.Z (no prerelease suffix).`,
       );
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "start:firefox": "web-ext run --source-dir=dist/firefox-direct --start-url=https://www.threads.com",
     "start:firefox:android": "bash scripts/run-firefox-android.sh",
     "setup:safari": "bash scripts/setup-safari-project.sh",
+    "set:safari-version": "bash scripts/set-safari-version.sh",
+    "check:versions": "node scripts/check-versions.js",
     "open:safari": "open dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj"
   },
   "repository": {

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -132,15 +132,22 @@ for (const rel of [
 // tags (`nightly`, `ios-1.0.7`, …) are not version-like, so they don't trip it.
 const headTags = getHeadTags();
 rows.push(["git tag(s) on HEAD", headTags.length ? headTags.join(", ") : "(none)"]);
-const versionLikeHeadTags = headTags.filter((t) => /^v?\d/.test(t));
-const hasMatchingReleaseTag = versionLikeHeadTags.some((t) => {
-  const v = t.replace(/^v/, "");
-  return isReleaseVersion(v) && v === tag;
-});
-if (versionLikeHeadTags.length > 0 && !hasMatchingReleaseTag) {
+// A version-like HEAD tag is optional-`v` then `digits.digit` — enough to catch
+// `v1.2` / `v1.2.3.4` while ignoring dates (`2026-08-08`) and unrelated tags
+// (`nightly`, `ios-1.0.7`). EVERY such tag must be a plain vX.Y.Z equal to the
+// resolved version: a per-tag check (not `.some`), so a good tag can't excuse a
+// bad sibling — e.g. `v1.2` + `v1.0.7` on one commit, where pushing `v1.2` is
+// what triggers release.yml.
+const badHeadTag = headTags
+  .filter((t) => /^v?\d+\.\d/.test(t))
+  .find((t) => {
+    const v = t.replace(/^v/, "");
+    return !(isReleaseVersion(v) && v === tag);
+  });
+if (badHeadTag) {
   problems.push(
-    `HEAD carries a version-like tag (${versionLikeHeadTags.join(", ")}) that is not a plain vX.Y.Z ` +
-      `matching the build's resolved version (${tag ?? "none"}). The build fell back to an ancestor tag — ` +
+    `HEAD carries a version-like tag "${badHeadTag}" that is not a plain vX.Y.Z matching the build's ` +
+      `resolved version (${tag ?? "none"}). The build would fall back to an ancestor tag — ` +
       `retag with a 3-part vX.Y.Z before releasing.`,
   );
 }

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -28,20 +28,19 @@ import { execSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { getGitVersion, isValidExtensionVersion, PLACEHOLDER_VERSION } from "./lib/version.js";
+import { getGitVersion, isValidExtensionVersion, isReleaseVersion, PLACEHOLDER_VERSION } from "./lib/version.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-// Tags pointing at HEAD, 'v' stripped. Used to catch the case where HEAD is
-// tagged with a shape the build can't use (e.g. `v1.2`), so the build resolves
+// Raw tags pointing at HEAD (e.g. ["v1.2", "nightly"]). Used to catch the case
+// where HEAD is tagged with a shape the build can't use, so the build resolves
 // to an ancestor tag and every other row agrees on that ancestor's version.
 function getHeadTags() {
   try {
     return execSync("git tag --points-at HEAD", { cwd: root, encoding: "utf-8" })
       .trim()
       .split("\n")
-      .filter(Boolean)
-      .map((t) => t.replace(/^v/, ""));
+      .filter(Boolean);
   } catch {
     return [];
   }
@@ -126,19 +125,24 @@ for (const rel of [
   }
 }
 
-// If HEAD is tagged but the build didn't resolve to that tag, HEAD's tag isn't a
-// version the build can use (e.g. `v1.2` or a prerelease) — `git describe` fell
-// back to an ancestor, so every other row agrees on the wrong version and would
-// otherwise pass. Catch it here so the LOCAL check matches release.yml's gate.
+// Catch a botched release tag so the LOCAL check matches release.yml's gate: if
+// HEAD carries a version-LIKE tag (starts with an optional `v` then a digit)
+// that isn't a plain vX.Y.Z equal to the resolved version, `git describe` fell
+// back to an ancestor and every other row would otherwise agree on it. Unrelated
+// tags (`nightly`, `ios-1.0.7`, …) are not version-like, so they don't trip it.
 const headTags = getHeadTags();
-if (headTags.length > 0) {
-  rows.push(["git tag(s) on HEAD", headTags.map((t) => `v${t}`).join(", ")]);
-  if (!headTags.includes(tag)) {
-    problems.push(
-      `HEAD is tagged ${headTags.map((t) => `v${t}`).join(", ")} but the build resolved to ${tag ?? "no version"} ` +
-        `(an ancestor tag). The tag on HEAD is not a plain vX.Y.Z version — retag before releasing.`,
-    );
-  }
+rows.push(["git tag(s) on HEAD", headTags.length ? headTags.join(", ") : "(none)"]);
+const versionLikeHeadTags = headTags.filter((t) => /^v?\d/.test(t));
+const hasMatchingReleaseTag = versionLikeHeadTags.some((t) => {
+  const v = t.replace(/^v/, "");
+  return isReleaseVersion(v) && v === tag;
+});
+if (versionLikeHeadTags.length > 0 && !hasMatchingReleaseTag) {
+  problems.push(
+    `HEAD carries a version-like tag (${versionLikeHeadTags.join(", ")}) that is not a plain vX.Y.Z ` +
+      `matching the build's resolved version (${tag ?? "none"}). The build fell back to an ancestor tag — ` +
+      `retag with a 3-part vX.Y.Z before releasing.`,
+  );
 }
 
 const width = Math.max(...rows.map((r) => r[0].length));

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -5,12 +5,20 @@
 // anything drifts from it — run it before a release / Safari archive, or in
 // CI after building.
 //
-//   node scripts/check-versions.js
+//   node scripts/check-versions.js          # full check (use before a Safari archive)
+//   node scripts/check-versions.js --web     # web artifacts only (skip MARKETING_VERSION)
 //   npm run check:versions
 //
 // Sources checked (each only when present):
 //   - Xcode MARKETING_VERSION in the Safari project's project.pbxproj
 //   - built dist/*/manifest.json (skipped if not built yet)
+//
+// --web skips MARKETING_VERSION: a web-only (Chrome/Firefox) release legitimately
+// leaves the Safari app version lagging, so package.sh uses --web to avoid failing
+// on that. A human cutting a Safari release runs the full check.
+//
+// Note: this is a release gate. A dev/watch build writes tag+1 into dist, so it
+// will (correctly) report a mismatch — run it against a production build.
 //
 // Note: src/manifest*.json is intentionally NOT checked — its version is a
 // 0.0.0 placeholder that the build overwrites from the git tag.
@@ -22,9 +30,15 @@ import { dirname, join } from "node:path";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
+// Must match esbuild.config.js — the version the build actually injects.
+const PLACEHOLDER_VERSION = "0.0.0";
+
 function getTag() {
   try {
-    return execSync("git describe --tags --abbrev=0", { cwd: root, encoding: "utf-8" })
+    return execSync(
+      "git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*'",
+      { cwd: root, encoding: "utf-8" },
+    )
       .trim()
       .replace(/^v/, "");
   } catch {
@@ -40,7 +54,8 @@ function getMarketingVersions() {
   if (!existsSync(pbxproj)) return null;
   const content = readFileSync(pbxproj, "utf-8");
   const versions = [...content.matchAll(/MARKETING_VERSION = ([^;]+);/g)].map((m) =>
-    m[1].trim(),
+    // pbxproj values may be quoted (MARKETING_VERSION = "1.0.6";) — strip them.
+    m[1].trim().replace(/^"|"$/g, ""),
   );
   return [...new Set(versions)];
 }
@@ -51,18 +66,17 @@ function getManifestVersion(rel) {
   return JSON.parse(readFileSync(p, "utf-8")).version;
 }
 
-const tag = getTag();
-if (!tag) {
-  console.error("❌ No git tag found. Tag the release first (git tag vX.Y.Z).");
-  process.exit(1);
-}
+const webOnly = process.argv.includes("--web");
 
-const rows = [["git tag (source of truth)", tag]];
+const tag = getTag();
+const rows = [["git tag (source of truth)", tag ?? "(none reachable)"]];
 const problems = [];
 
 // Xcode MARKETING_VERSION (the hand-edited value that drifted before).
-const mv = getMarketingVersions();
-if (mv === null) {
+const mv = webOnly ? null : getMarketingVersions();
+if (webOnly) {
+  rows.push(["Xcode MARKETING_VERSION", "(--web: skipped)"]);
+} else if (mv === null) {
   rows.push(["Xcode MARKETING_VERSION", "(project not found — skipped)"]);
 } else if (mv.length === 0) {
   rows.push(["Xcode MARKETING_VERSION", "(none found — skipped)"]);
@@ -70,9 +84,11 @@ if (mv === null) {
   rows.push(["Xcode MARKETING_VERSION", mv.join(", ")]);
   if (mv.length > 1) {
     problems.push(`MARKETING_VERSION is inconsistent across build configs: ${mv.join(", ")}`);
-  } else if (mv[0] !== tag) {
+  } else if (mv[0] === PLACEHOLDER_VERSION) {
+    problems.push(`MARKETING_VERSION is the ${PLACEHOLDER_VERSION} placeholder — run: bash scripts/set-safari-version.sh <version>`);
+  } else if (tag && mv[0] !== tag) {
     problems.push(
-      `MARKETING_VERSION (${mv[0]}) != git tag (${tag}). Run: bash scripts/set-safari-version.sh`,
+      `MARKETING_VERSION (${mv[0]}) != git tag (${tag}). Run: bash scripts/set-safari-version.sh ${tag}`,
     );
   }
 }
@@ -88,8 +104,15 @@ for (const rel of [
   const v = getManifestVersion(rel);
   if (v == null) continue;
   rows.push([rel, v]);
-  if (v !== tag) {
-    problems.push(`${rel} (${v}) != git tag (${tag}). Rebuild with the tag checked out.`);
+  // A placeholder in a built manifest is always wrong — the build could not
+  // resolve a real version. Flag it even when no tag is reachable, since that
+  // is exactly the state that produces a bad 0.0.0 artifact.
+  if (v === PLACEHOLDER_VERSION) {
+    problems.push(`${rel} is the ${PLACEHOLDER_VERSION} placeholder — the build could not resolve a version. Run "git fetch --tags" and rebuild.`);
+  } else if (tag && v !== tag) {
+    problems.push(
+      `${rel} (${v}) != git tag (${tag}). Rebuild with the tag checked out, or run "npm run clean" to clear a stale build.`,
+    );
   }
 }
 
@@ -98,8 +121,16 @@ console.log("\nVersion check:");
 for (const [k, v] of rows) console.log(`  ${k.padEnd(width)}  ${v}`);
 console.log("");
 
+// With no tag we can't verify against the source of truth. If nothing else is
+// obviously broken, still fail — an unverifiable release is not a passing one.
+if (!tag && problems.length === 0) {
+  console.error("⚠️  No semver git tag reachable — cannot verify versions against the source of truth.");
+  console.error('   Tag the release (git tag vX.Y.Z) or run "git fetch --tags".');
+  process.exit(1);
+}
+
 if (problems.length) {
-  console.error("❌ Version mismatch:");
+  console.error("❌ Version check failed:");
   for (const p of problems) console.error(`   - ${p}`);
   process.exit(1);
 }

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Verify every version source agrees with the latest git tag.
+//
+// The git tag is the single source of truth. This guard fails the run when
+// anything drifts from it — run it before a release / Safari archive, or in
+// CI after building.
+//
+//   node scripts/check-versions.js
+//   npm run check:versions
+//
+// Sources checked (each only when present):
+//   - Xcode MARKETING_VERSION in the Safari project's project.pbxproj
+//   - built dist/*/manifest.json (skipped if not built yet)
+//
+// Note: src/manifest*.json is intentionally NOT checked — its version is a
+// 0.0.0 placeholder that the build overwrites from the git tag.
+
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function getTag() {
+  try {
+    return execSync("git describe --tags --abbrev=0", { cwd: root, encoding: "utf-8" })
+      .trim()
+      .replace(/^v/, "");
+  } catch {
+    return null;
+  }
+}
+
+function getMarketingVersions() {
+  const pbxproj = join(
+    root,
+    "dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj",
+  );
+  if (!existsSync(pbxproj)) return null;
+  const content = readFileSync(pbxproj, "utf-8");
+  const versions = [...content.matchAll(/MARKETING_VERSION = ([^;]+);/g)].map((m) =>
+    m[1].trim(),
+  );
+  return [...new Set(versions)];
+}
+
+function getManifestVersion(rel) {
+  const p = join(root, rel);
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8")).version;
+}
+
+const tag = getTag();
+if (!tag) {
+  console.error("❌ No git tag found. Tag the release first (git tag vX.Y.Z).");
+  process.exit(1);
+}
+
+const rows = [["git tag (source of truth)", tag]];
+const problems = [];
+
+// Xcode MARKETING_VERSION (the hand-edited value that drifted before).
+const mv = getMarketingVersions();
+if (mv === null) {
+  rows.push(["Xcode MARKETING_VERSION", "(project not found — skipped)"]);
+} else if (mv.length === 0) {
+  rows.push(["Xcode MARKETING_VERSION", "(none found — skipped)"]);
+} else {
+  rows.push(["Xcode MARKETING_VERSION", mv.join(", ")]);
+  if (mv.length > 1) {
+    problems.push(`MARKETING_VERSION is inconsistent across build configs: ${mv.join(", ")}`);
+  } else if (mv[0] !== tag) {
+    problems.push(
+      `MARKETING_VERSION (${mv[0]}) != git tag (${tag}). Run: bash scripts/set-safari-version.sh`,
+    );
+  }
+}
+
+// Built dist manifests (present only after a build).
+for (const rel of [
+  "dist/chrome/manifest.json",
+  "dist/firefox/manifest.json",
+  "dist/firefox-amo/manifest.json",
+  "dist/firefox-direct/manifest.json",
+  "dist/safari/manifest.json",
+]) {
+  const v = getManifestVersion(rel);
+  if (v == null) continue;
+  rows.push([rel, v]);
+  if (v !== tag) {
+    problems.push(`${rel} (${v}) != git tag (${tag}). Rebuild with the tag checked out.`);
+  }
+}
+
+const width = Math.max(...rows.map((r) => r[0].length));
+console.log("\nVersion check:");
+for (const [k, v] of rows) console.log(`  ${k.padEnd(width)}  ${v}`);
+console.log("");
+
+if (problems.length) {
+  console.error("❌ Version mismatch:");
+  for (const p of problems) console.error(`   - ${p}`);
+  process.exit(1);
+}
+
+console.log("✅ All present version sources match the git tag.");

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -24,12 +24,28 @@
 // overwrites from the tag) and package.json's version (npm-local metadata, not
 // read by the build and not shipped in any artifact).
 
+import { execSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { getGitVersion, isValidExtensionVersion, PLACEHOLDER_VERSION } from "./lib/version.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Tags pointing at HEAD, 'v' stripped. Used to catch the case where HEAD is
+// tagged with a shape the build can't use (e.g. `v1.2`), so the build resolves
+// to an ancestor tag and every other row agrees on that ancestor's version.
+function getHeadTags() {
+  try {
+    return execSync("git tag --points-at HEAD", { cwd: root, encoding: "utf-8" })
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((t) => t.replace(/^v/, ""));
+  } catch {
+    return [];
+  }
+}
 
 // Shared with the build (scripts/lib/version.js): same glob AND the same semver
 // validation, so a tag the build would reject (e.g. a prerelease) can't slip
@@ -106,6 +122,21 @@ for (const rel of [
   } else if (tag && v !== tag) {
     problems.push(
       `${rel} (${v}) != git tag (${tag}). Rebuild with the tag checked out, or run "npm run clean" to clear a stale build.`,
+    );
+  }
+}
+
+// If HEAD is tagged but the build didn't resolve to that tag, HEAD's tag isn't a
+// version the build can use (e.g. `v1.2` or a prerelease) — `git describe` fell
+// back to an ancestor, so every other row agrees on the wrong version and would
+// otherwise pass. Catch it here so the LOCAL check matches release.yml's gate.
+const headTags = getHeadTags();
+if (headTags.length > 0) {
+  rows.push(["git tag(s) on HEAD", headTags.map((t) => `v${t}`).join(", ")]);
+  if (!headTags.includes(tag)) {
+    problems.push(
+      `HEAD is tagged ${headTags.map((t) => `v${t}`).join(", ")} but the build resolved to ${tag ?? "no version"} ` +
+        `(an ancestor tag). The tag on HEAD is not a plain vX.Y.Z version — retag before releasing.`,
     );
   }
 }

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -27,7 +27,7 @@
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { getGitVersion, PLACEHOLDER_VERSION } from "./lib/version.js";
+import { getGitVersion, isValidExtensionVersion, PLACEHOLDER_VERSION } from "./lib/version.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -96,11 +96,13 @@ for (const rel of [
   const v = getManifestVersion(rel);
   if (v == null) continue;
   rows.push([rel, v]);
-  // A placeholder in a built manifest is always wrong — the build could not
-  // resolve a real version. Flag it even when no tag is reachable, since that
-  // is exactly the state that produces a bad 0.0.0 artifact.
+  // Flag bad built versions even when no tag is reachable — that is exactly the
+  // state that ships them. A placeholder means the build couldn't resolve a
+  // version; a non-semver value means a prerelease/invalid tag reached it.
   if (v === PLACEHOLDER_VERSION) {
     problems.push(`${rel} is the ${PLACEHOLDER_VERSION} placeholder — the build could not resolve a version. Run "git fetch --tags" and rebuild.`);
+  } else if (!isValidExtensionVersion(v)) {
+    problems.push(`${rel} has an invalid version "${v}" — not a valid extension version. A prerelease or malformed tag reached the build; tag with a plain vX.Y.Z and rebuild.`);
   } else if (tag && v !== tag) {
     problems.push(
       `${rel} (${v}) != git tag (${tag}). Rebuild with the tag checked out, or run "npm run clean" to clear a stale build.`,

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -20,30 +20,22 @@
 // Note: this is a release gate. A dev/watch build writes tag+1 into dist, so it
 // will (correctly) report a mismatch — run it against a production build.
 //
-// Note: src/manifest*.json is intentionally NOT checked — its version is a
-// 0.0.0 placeholder that the build overwrites from the git tag.
+// Not checked, by design: src/manifest*.json (a 0.0.0 placeholder the build
+// overwrites from the tag) and package.json's version (npm-local metadata, not
+// read by the build and not shipped in any artifact).
 
-import { execSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { getGitVersion, PLACEHOLDER_VERSION } from "./lib/version.js";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-// Must match esbuild.config.js — the version the build actually injects.
-const PLACEHOLDER_VERSION = "0.0.0";
-
+// Shared with the build (scripts/lib/version.js): same glob AND the same semver
+// validation, so a tag the build would reject (e.g. a prerelease) can't slip
+// past the guard by comparing an invalid version against itself.
 function getTag() {
-  try {
-    return execSync(
-      "git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*'",
-      { cwd: root, encoding: "utf-8" },
-    )
-      .trim()
-      .replace(/^v/, "");
-  } catch {
-    return null;
-  }
+  return getGitVersion({ cwd: root });
 }
 
 function getMarketingVersions() {

--- a/scripts/lib/version.js
+++ b/scripts/lib/version.js
@@ -58,7 +58,9 @@ function computeGitVersion(cwd) {
   } catch (error) {
     const message = error.message || String(error);
     if (/No names found|No tags|cannot describe/.test(message)) {
-      console.warn("⚠️  No matching git version tag found; falling back to manifest version");
+      // Neutral wording: this module is shared, and not every caller has a
+      // manifest fallback (check-versions.js does not).
+      console.warn("⚠️  No matching git version tag found");
     } else {
       console.warn("⚠️  Could not get git version:", message.split("\n")[0]);
     }

--- a/scripts/lib/version.js
+++ b/scripts/lib/version.js
@@ -26,6 +26,15 @@ export function isValidExtensionVersion(version) {
   return typeof version === "string" && EXTENSION_VERSION_RE.test(version);
 }
 
+// A release tag is exactly X.Y.Z — stricter than a manifest version (App Store
+// MARKETING_VERSION allows at most 3 parts), and what release.yml enforces on
+// the pushed tag. EXTENSION_VERSION_RE stays the looser "what a manifest holds".
+export const RELEASE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+export function isReleaseVersion(version) {
+  return typeof version === "string" && RELEASE_VERSION_RE.test(version);
+}
+
 // Turn a raw `git describe` tag ("v1.0.6", "1.0.6", "v1.2.3-beta.1", …) into a
 // valid extension version, or null. Pure — the unit tests exercise this so the
 // glob/regex divergence that caused past bugs is caught without touching git.

--- a/scripts/lib/version.js
+++ b/scripts/lib/version.js
@@ -35,14 +35,17 @@ export function normalizeTag(tag) {
   return isValidExtensionVersion(version) ? version : null;
 }
 
-let cachedGitVersion;
+// Memoized per cwd so distinct working directories don't share a result and
+// repeated calls in one build spawn `git` once.
+const gitVersionCache = new Map();
 
 // Latest valid version from git tags (e.g. "v1.0.6" -> "1.0.6"), or null when
 // none is reachable or the newest matching tag isn't a valid extension version
-// (e.g. a prerelease tag). Memoized so one process resolves it once.
-export function getGitVersion(options = {}) {
-  if (cachedGitVersion === undefined) cachedGitVersion = computeGitVersion(options.cwd);
-  return cachedGitVersion;
+// (e.g. a prerelease tag).
+export function getGitVersion({ cwd } = {}) {
+  const key = cwd ?? "";
+  if (!gitVersionCache.has(key)) gitVersionCache.set(key, computeGitVersion(cwd));
+  return gitVersionCache.get(key);
 }
 
 function computeGitVersion(cwd) {
@@ -68,7 +71,7 @@ function computeGitVersion(cwd) {
 
 // Reset the memoized value (unit tests only).
 export function _resetGitVersionCache() {
-  cachedGitVersion = undefined;
+  gitVersionCache.clear();
 }
 
 // Increment the patch version (e.g., "0.3.7" -> "0.3.8").

--- a/scripts/lib/version.js
+++ b/scripts/lib/version.js
@@ -1,10 +1,11 @@
 // Single source of truth for how a version is derived and validated.
 //
 // The build (esbuild.config.js) and the release guard (check-versions.js) both
-// import from here so the rules can't drift apart. set-safari-version.sh is
-// bash and can't import this — it keeps its own check, deliberately stricter
-// (App Store marketing versions allow at most 3 parts, Chrome MV3 allows 4);
-// that difference is intentional and noted in the shell script.
+// import from here so the rules can't drift apart. Two callers can't import it
+// and keep their own copy on purpose: set-safari-version.sh (bash) and
+// .github/workflows/release.yml both validate the release tag as exactly 3
+// parts — deliberately stricter than EXTENSION_VERSION_RE (Chrome MV3 allows 4,
+// the App Store allows 3). Keep those in sync with RELEASE_VERSION_RE below.
 
 import { execSync } from "node:child_process";
 

--- a/scripts/lib/version.js
+++ b/scripts/lib/version.js
@@ -1,0 +1,86 @@
+// Single source of truth for how a version is derived and validated.
+//
+// The build (esbuild.config.js) and the release guard (check-versions.js) both
+// import from here so the rules can't drift apart. set-safari-version.sh is
+// bash and can't import this — it keeps its own check, deliberately stricter
+// (App Store marketing versions allow at most 3 parts, Chrome MV3 allows 4);
+// that difference is intentional and noted in the shell script.
+
+import { execSync } from "node:child_process";
+
+// Placeholder written in src/manifest*.json — the real version is injected at
+// build time from the git tag and must never reach a shipped artifact.
+export const PLACEHOLDER_VERSION = "0.0.0";
+
+// git describe glob that pre-filters to version tags. This is a GLOB, not a
+// regex ('*' matches anything, including "-beta.1"), so it only narrows the
+// candidates — every result must still pass EXTENSION_VERSION_RE below.
+export const VERSION_TAG_GLOB = "v[0-9]*.[0-9]*.[0-9]*";
+
+// A valid Chrome MV3 version: 1–4 dot-separated integers. Authoritative for
+// anything written into a web extension manifest. (In practice the git-tag
+// glob only yields 3+ part versions; this stays faithful to the spec anyway.)
+export const EXTENSION_VERSION_RE = /^\d+(\.\d+){0,3}$/;
+
+export function isValidExtensionVersion(version) {
+  return typeof version === "string" && EXTENSION_VERSION_RE.test(version);
+}
+
+// Turn a raw `git describe` tag ("v1.0.6", "1.0.6", "v1.2.3-beta.1", …) into a
+// valid extension version, or null. Pure — the unit tests exercise this so the
+// glob/regex divergence that caused past bugs is caught without touching git.
+export function normalizeTag(tag) {
+  if (!tag) return null;
+  const version = tag.startsWith("v") ? tag.slice(1) : tag;
+  return isValidExtensionVersion(version) ? version : null;
+}
+
+let cachedGitVersion;
+
+// Latest valid version from git tags (e.g. "v1.0.6" -> "1.0.6"), or null when
+// none is reachable or the newest matching tag isn't a valid extension version
+// (e.g. a prerelease tag). Memoized so one process resolves it once.
+export function getGitVersion(options = {}) {
+  if (cachedGitVersion === undefined) cachedGitVersion = computeGitVersion(options.cwd);
+  return cachedGitVersion;
+}
+
+function computeGitVersion(cwd) {
+  let tag;
+  try {
+    tag = execSync(`git describe --tags --abbrev=0 --match='${VERSION_TAG_GLOB}'`, {
+      cwd,
+      encoding: "utf-8",
+    }).trim();
+  } catch (error) {
+    const message = error.message || String(error);
+    if (/No names found|No tags|cannot describe/.test(message)) {
+      console.warn("⚠️  No matching git version tag found; falling back to manifest version");
+    } else {
+      console.warn("⚠️  Could not get git version:", message.split("\n")[0]);
+    }
+    return null;
+  }
+  const version = normalizeTag(tag);
+  if (version === null) console.warn(`⚠️  Ignoring non-semver git tag "${tag}"`);
+  return version;
+}
+
+// Reset the memoized value (unit tests only).
+export function _resetGitVersionCache() {
+  cachedGitVersion = undefined;
+}
+
+// Increment the patch version (e.g., "0.3.7" -> "0.3.8").
+export function incrementVersion(version) {
+  const parts = version.split(".");
+  if (parts.length < 3) {
+    throw new Error(`Invalid version format "${version}". Expected semver format (X.Y.Z)`);
+  }
+  const patchNum = Number(parts[2]);
+  if (isNaN(patchNum)) {
+    throw new Error(`Invalid patch version "${parts[2]}" in version "${version}". Must be a number`);
+  }
+  parts[2] = String(patchNum + 1);
+  return parts.join(".");
+}

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -10,9 +10,16 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 cd "$PROJECT_ROOT"
 
-# Build the extension first
+# Start from a clean dist/ so a leftover build from an older version can't be
+# packaged or trip the version guard below.
+echo "🧹 Cleaning previous build output..."
+npm run clean
+
+# Build both the default (dist/firefox) and AMO (dist/firefox-amo) outputs so
+# this script is self-contained and never packages a stale directory.
 echo "🔨 Building extension..."
 npm run build
+npm run build:firefox-amo
 
 # Get version from manifest.json in dist/chrome/
 VERSION=$(grep '"version"' dist/chrome/manifest.json | sed 's/.*"version": "\(.*\)".*/\1/')
@@ -38,13 +45,6 @@ echo "📊 Size: $(du -h dist-zip/lee-su-threads-chrome-v${VERSION}.zip | cut -f
 echo ""
 echo "🦊 Building Firefox extension..."
 
-# Check if firefox-amo directory exists (AMO unlisted build)
-if [ ! -d "dist/firefox-amo" ]; then
-  echo "❌ Error: dist/firefox-amo/ not found"
-  echo "   Run 'npm run build:firefox-amo' first"
-  exit 1
-fi
-
 echo "📦 Building AMO version (for unlisted review)..."
 cd dist/firefox-amo
 zip -r "$PROJECT_ROOT/dist-zip/lee-su-threads-firefox-v${VERSION}-amo.zip" . -x "*.DS_Store" "*.map"
@@ -52,6 +52,13 @@ cd "$PROJECT_ROOT"
 
 echo "✅ Created dist-zip/lee-su-threads-firefox-v${VERSION}-amo.zip (AMO unlisted)"
 echo "📊 Size: $(du -h dist-zip/lee-su-threads-firefox-v${VERSION}-amo.zip | cut -f1)"
+
+# Verify the packaged web artifacts match the git tag before we call it done.
+# --web skips MARKETING_VERSION: this script only packages Chrome/Firefox, and
+# the Safari app version legitimately lags on a web-only release.
+echo ""
+echo "🔎 Verifying versions against the git tag..."
+node "$SCRIPT_DIR/check-versions.js" --web
 
 echo ""
 echo "🎉 All builds complete!"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -21,6 +21,13 @@ echo "🔨 Building extension..."
 npm run build
 npm run build:firefox-amo
 
+# Verify the built web artifacts match the git tag BEFORE zipping, so a
+# mismatch aborts (set -e) without leaving a wrongly-named zip in dist-zip/.
+# --web skips MARKETING_VERSION: this script only packages Chrome/Firefox, and
+# the Safari app version legitimately lags on a web-only release.
+echo "🔎 Verifying versions against the git tag..."
+node "$SCRIPT_DIR/check-versions.js" --web
+
 # Get version from manifest.json in dist/chrome/
 VERSION=$(grep '"version"' dist/chrome/manifest.json | sed 's/.*"version": "\(.*\)".*/\1/')
 
@@ -53,19 +60,9 @@ cd "$PROJECT_ROOT"
 echo "✅ Created dist-zip/lee-su-threads-firefox-v${VERSION}-amo.zip (AMO unlisted)"
 echo "📊 Size: $(du -h dist-zip/lee-su-threads-firefox-v${VERSION}-amo.zip | cut -f1)"
 
-# Verify the packaged web artifacts match the git tag before we call it done.
-# --web skips MARKETING_VERSION: this script only packages Chrome/Firefox, and
-# the Safari app version legitimately lags on a web-only release.
-echo ""
-echo "🔎 Verifying versions against the git tag..."
-node "$SCRIPT_DIR/check-versions.js" --web
-
 echo ""
 echo "🎉 All builds complete!"
 echo ""
 echo "Chrome:  dist-zip/lee-su-threads-chrome-v${VERSION}.zip"
-
 echo "Firefox (AMO): dist-zip/lee-su-threads-firefox-v${VERSION}-amo.zip"
-if [ -d "dist/firefox-direct" ]; then
-  echo "Firefox (Direct Install): Will be signed and created as .xpi in CI"
-fi
+echo "Firefox (Direct Install): built and signed as .xpi separately in CI"

--- a/scripts/set-safari-version.sh
+++ b/scripts/set-safari-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Set the Safari/iOS app's Xcode MARKETING_VERSION from the latest git tag.
+#
+# macOS + Xcode only (uses `agvtool`). Run this before archiving the Safari
+# app for App Store submission so the App Store version always matches the
+# git tag — never hand-edit MARKETING_VERSION in project.pbxproj again.
+#
+# Usage:
+#   bash scripts/set-safari-version.sh          # use the latest git tag
+#   bash scripts/set-safari-version.sh 1.0.6    # override explicitly
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+XCODE_DIR="$PROJECT_ROOT/dist-safari/safari-project/Lee-Su-Sui"
+
+if ! command -v xcrun >/dev/null 2>&1 || ! xcrun --find agvtool >/dev/null 2>&1; then
+  echo "❌ agvtool not available. This script requires macOS with Xcode installed." >&2
+  exit 1
+fi
+
+if [ ! -d "$XCODE_DIR" ]; then
+  echo "❌ Xcode project not found at:" >&2
+  echo "   $XCODE_DIR" >&2
+  echo "   Run 'npm run setup:safari' first to generate it." >&2
+  exit 1
+fi
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  TAG="$(git -C "$PROJECT_ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
+  VERSION="${TAG#v}"
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "❌ No version given and no git tag found. Tag the release first (git tag vX.Y.Z)." >&2
+  exit 1
+fi
+
+echo "🍎 Setting Safari MARKETING_VERSION → $VERSION"
+( cd "$XCODE_DIR" && xcrun agvtool new-marketing-version "$VERSION" >/dev/null )
+
+CURRENT="$( cd "$XCODE_DIR" && xcrun agvtool what-marketing-version -terse 2>/dev/null | tail -n 1 || true )"
+echo "✅ Done (MARKETING_VERSION is now ${CURRENT:-$VERSION})."

--- a/scripts/set-safari-version.sh
+++ b/scripts/set-safari-version.sh
@@ -7,9 +7,18 @@ set -euo pipefail
 # app for App Store submission so the App Store version always matches the
 # git tag — never hand-edit MARKETING_VERSION in project.pbxproj again.
 #
+# Because project.pbxproj is tracked in git, the commit that sets the version
+# must exist *before* the tag points at it. The reliable release order is:
+#
+#   bash scripts/set-safari-version.sh 1.0.7   # set + git commit the pbxproj
+#   git tag v1.0.7 && git push origin v1.0.7   # then tag that commit
+#
+# The no-argument form reads the latest tag and is meant for re-syncing an
+# existing project, not for cutting a new release.
+#
 # Usage:
-#   bash scripts/set-safari-version.sh          # use the latest git tag
-#   bash scripts/set-safari-version.sh 1.0.6    # override explicitly
+#   bash scripts/set-safari-version.sh 1.0.7    # explicit version (release)
+#   bash scripts/set-safari-version.sh          # re-sync from the latest git tag
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 XCODE_DIR="$PROJECT_ROOT/dist-safari/safari-project/Lee-Su-Sui"
@@ -28,12 +37,22 @@ fi
 
 VERSION="${1:-}"
 if [ -z "$VERSION" ]; then
-  TAG="$(git -C "$PROJECT_ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
-  VERSION="${TAG#v}"
+  # --match keeps a stray tag (ios-*, nightly) from being read as the version.
+  TAG="$(git -C "$PROJECT_ROOT" describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || true)"
+  VERSION="$TAG"
 fi
 
+# Strip a leading 'v' on either path so "v1.0.6" and "1.0.6" both work.
+VERSION="${VERSION#v}"
+
 if [ -z "$VERSION" ]; then
-  echo "❌ No version given and no git tag found. Tag the release first (git tag vX.Y.Z)." >&2
+  echo "❌ No version given and no matching git tag found. Pass one explicitly: set-safari-version.sh 1.0.7" >&2
+  exit 1
+fi
+
+# App Store Connect only accepts a numeric dotted version.
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}$'; then
+  echo "❌ Invalid version \"$VERSION\". Expected a numeric version like 1.0.6." >&2
   exit 1
 fi
 

--- a/scripts/set-safari-version.sh
+++ b/scripts/set-safari-version.sh
@@ -64,5 +64,5 @@ fi
 echo "🍎 Setting Safari MARKETING_VERSION → $VERSION"
 ( cd "$XCODE_DIR" && xcrun agvtool new-marketing-version "$VERSION" >/dev/null )
 
-CURRENT="$( cd "$XCODE_DIR" && xcrun agvtool what-marketing-version -terse 2>/dev/null | tail -n 1 || true )"
+CURRENT="$( cd "$XCODE_DIR" && xcrun agvtool what-marketing-version -terse1 2>/dev/null | tail -n 1 || true )"
 echo "✅ Done (MARKETING_VERSION is now ${CURRENT:-$VERSION})."

--- a/scripts/set-safari-version.sh
+++ b/scripts/set-safari-version.sh
@@ -50,9 +50,14 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
-# App Store Connect only accepts a numeric dotted version.
+# App Store Connect only accepts a numeric version of at most three parts
+# (X, X.Y, or X.Y.Z). This is DELIBERATELY stricter than the extension's
+# EXTENSION_VERSION_RE in scripts/lib/version.js, which allows a 4th part
+# because Chrome MV3 does. Bash can't import that module, so the rule is
+# duplicated here on purpose — keep the two in sync when either platform's
+# constraints change.
 if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}$'; then
-  echo "❌ Invalid version \"$VERSION\". Expected a numeric version like 1.0.6." >&2
+  echo "❌ Invalid version \"$VERSION\". Expected a numeric version like 1.0.6 (max 3 parts for the App Store)." >&2
   exit 1
 fi
 

--- a/src/manifest.firefox-direct.json
+++ b/src/manifest.firefox-direct.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__ (Direct)",
-  "version": "0.3.7",
+  "version": "0.0.0",
   "description": "__MSG_extDescription__",
   "default_locale": "zh_TW",
   "permissions": [

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.3.7",
+  "version": "0.0.0",
   "description": "__MSG_extDescription__",
   "default_locale": "zh_TW",
   "permissions": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.3.7",
+  "version": "0.0.0",
   "description": "__MSG_extDescription__",
   "default_locale": "zh_TW",
   "permissions": [

--- a/src/manifest.safari.json
+++ b/src/manifest.safari.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extName__",
-  "version": "0.3.7",
+  "version": "0.0.0",
   "description": "__MSG_extDescription__",
   "default_locale": "zh_TW",
   "permissions": [

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
 import {
   EXTENSION_VERSION_RE,
   PLACEHOLDER_VERSION,
@@ -75,16 +79,57 @@ describe("incrementVersion", () => {
 });
 
 describe("getGitVersion", () => {
-  it("returns null or a valid extension version, and never a raw/invalid tag", () => {
+  const repos = [];
+
+  // A throwaway git repo whose newest matching tag is `tag` (or none).
+  function repoWithTag(tag) {
+    const dir = mkdtempSync(join(tmpdir(), "lst-ver-"));
+    repos.push(dir);
+    const run = (cmd) => execSync(cmd, { cwd: dir, stdio: "pipe" });
+    run("git init -q");
+    run('git config user.email "t@example.com"');
+    run('git config user.name "t"');
+    run('git commit -q --allow-empty -m init');
+    if (tag) run(`git tag ${tag}`);
+    return dir;
+  }
+
+  afterEach(() => {
     _resetGitVersionCache();
-    const v = getGitVersion();
-    if (v !== null) expect(isValidExtensionVersion(v)).toBe(true);
+    while (repos.length) rmSync(repos.pop(), { recursive: true, force: true });
   });
 
-  it("memoizes per cwd (repeated calls return the same value)", () => {
+  it("returns the stripped version for a valid tag", () => {
     _resetGitVersionCache();
-    const first = getGitVersion();
-    const second = getGitVersion();
-    expect(second).toBe(first);
+    expect(getGitVersion({ cwd: repoWithTag("v2.3.4") })).toBe("2.3.4");
+  });
+
+  it("returns null for a prerelease tag the glob lets through", () => {
+    _resetGitVersionCache();
+    expect(getGitVersion({ cwd: repoWithTag("v1.2.3-beta.1") })).toBeNull();
+  });
+
+  it("returns null when no matching tag exists", () => {
+    _resetGitVersionCache();
+    expect(getGitVersion({ cwd: repoWithTag(null) })).toBeNull();
+  });
+
+  it("memoizes per cwd — a tag added after the first call is not seen", () => {
+    _resetGitVersionCache();
+    const dir = repoWithTag("v1.0.0");
+    expect(getGitVersion({ cwd: dir })).toBe("1.0.0");
+    // Newer tag on a NEW commit so `git describe` deterministically prefers it.
+    execSync('git commit -q --allow-empty -m next && git tag v1.0.1', { cwd: dir, stdio: "pipe" });
+    expect(getGitVersion({ cwd: dir })).toBe("1.0.0"); // cached — new tag not seen
+    _resetGitVersionCache();
+    expect(getGitVersion({ cwd: dir })).toBe("1.0.1"); // re-read after reset
+  });
+
+  it("keys the cache per cwd (distinct repos resolve independently)", () => {
+    _resetGitVersionCache();
+    const a = repoWithTag("v3.0.0");
+    const b = repoWithTag("v4.0.0");
+    expect(getGitVersion({ cwd: a })).toBe("3.0.0");
+    expect(getGitVersion({ cwd: b })).toBe("4.0.0");
   });
 });

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -5,6 +5,8 @@ import {
   isValidExtensionVersion,
   normalizeTag,
   incrementVersion,
+  getGitVersion,
+  _resetGitVersionCache,
 } from "../scripts/lib/version.js";
 
 describe("isValidExtensionVersion", () => {
@@ -69,5 +71,20 @@ describe("incrementVersion", () => {
 
   it("throws when the patch component is not numeric", () => {
     expect(() => incrementVersion("1.0.x")).toThrow(/Invalid patch version/);
+  });
+});
+
+describe("getGitVersion", () => {
+  it("returns null or a valid extension version, and never a raw/invalid tag", () => {
+    _resetGitVersionCache();
+    const v = getGitVersion();
+    if (v !== null) expect(isValidExtensionVersion(v)).toBe(true);
+  });
+
+  it("memoizes per cwd (repeated calls return the same value)", () => {
+    _resetGitVersionCache();
+    const first = getGitVersion();
+    const second = getGitVersion();
+    expect(second).toBe(first);
   });
 });

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -7,6 +7,7 @@ import {
   EXTENSION_VERSION_RE,
   PLACEHOLDER_VERSION,
   isValidExtensionVersion,
+  isReleaseVersion,
   normalizeTag,
   incrementVersion,
   getGitVersion,
@@ -36,6 +37,25 @@ describe("isValidExtensionVersion", () => {
     // 0.0.0 is a shape-valid version; the build/guard reject it by identity,
     // not by shape. This documents that distinction.
     expect(EXTENSION_VERSION_RE.test(PLACEHOLDER_VERSION)).toBe(true);
+  });
+});
+
+describe("isReleaseVersion", () => {
+  it("accepts exactly three numeric parts", () => {
+    for (const v of ["1.0.6", "0.0.0", "10.20.30"]) expect(isReleaseVersion(v)).toBe(true);
+  });
+
+  it("rejects fewer or more than three parts, and prereleases", () => {
+    // The deliberate divergence: 1.2.3.4 is a valid manifest version but NOT a
+    // valid release tag. Pinning it so a later regex "harmonisation" can't undo it.
+    for (const v of ["1.2", "1", "1.2.3.4", "1.2.3-beta.1", "v1.0.6"]) {
+      expect(isReleaseVersion(v)).toBe(false);
+    }
+  });
+
+  it("is stricter than isValidExtensionVersion for a 4-part version", () => {
+    expect(isValidExtensionVersion("1.2.3.4")).toBe(true);
+    expect(isReleaseVersion("1.2.3.4")).toBe(false);
   });
 });
 

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -81,12 +81,15 @@ describe("incrementVersion", () => {
 describe("getGitVersion", () => {
   const repos = [];
 
-  // Git env scrubbed so the fixture is hermetic: GIT_DIR/GIT_WORK_TREE (set when
-  // git runs us from a hook) would otherwise redirect these commands at the real
-  // repo, and a global commit.gpgsign would make --allow-empty fail.
-  const cleanEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
-  delete cleanEnv.GIT_DIR;
-  delete cleanEnv.GIT_WORK_TREE;
+  // Git env scrubbed so the fixture is hermetic: any inherited GIT_* var (DIR,
+  // WORK_TREE, INDEX_FILE, OBJECT_DIRECTORY, COMMON_DIR — all set when git runs
+  // us from a hook) would redirect these commands at the real repo, and a global
+  // commit.gpgsign would make --allow-empty fail. Drop every GIT_* key, then
+  // point config at /dev/null.
+  const cleanEnv = { ...process.env };
+  for (const k of Object.keys(cleanEnv)) if (k.startsWith("GIT_")) delete cleanEnv[k];
+  cleanEnv.GIT_CONFIG_GLOBAL = "/dev/null";
+  cleanEnv.GIT_CONFIG_SYSTEM = "/dev/null";
 
   // A throwaway git repo whose newest matching tag is `tag` (or none).
   function repoWithTag(tag) {

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -81,11 +81,18 @@ describe("incrementVersion", () => {
 describe("getGitVersion", () => {
   const repos = [];
 
+  // Git env scrubbed so the fixture is hermetic: GIT_DIR/GIT_WORK_TREE (set when
+  // git runs us from a hook) would otherwise redirect these commands at the real
+  // repo, and a global commit.gpgsign would make --allow-empty fail.
+  const cleanEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
+  delete cleanEnv.GIT_DIR;
+  delete cleanEnv.GIT_WORK_TREE;
+
   // A throwaway git repo whose newest matching tag is `tag` (or none).
   function repoWithTag(tag) {
     const dir = mkdtempSync(join(tmpdir(), "lst-ver-"));
     repos.push(dir);
-    const run = (cmd) => execSync(cmd, { cwd: dir, stdio: "pipe" });
+    const run = (cmd) => execSync(cmd, { cwd: dir, stdio: "pipe", env: cleanEnv });
     run("git init -q");
     run('git config user.email "t@example.com"');
     run('git config user.name "t"');
@@ -119,7 +126,7 @@ describe("getGitVersion", () => {
     const dir = repoWithTag("v1.0.0");
     expect(getGitVersion({ cwd: dir })).toBe("1.0.0");
     // Newer tag on a NEW commit so `git describe` deterministically prefers it.
-    execSync('git commit -q --allow-empty -m next && git tag v1.0.1', { cwd: dir, stdio: "pipe" });
+    execSync('git commit -q --allow-empty -m next && git tag v1.0.1', { cwd: dir, stdio: "pipe", env: cleanEnv });
     expect(getGitVersion({ cwd: dir })).toBe("1.0.0"); // cached — new tag not seen
     _resetGitVersionCache();
     expect(getGitVersion({ cwd: dir })).toBe("1.0.1"); // re-read after reset

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  EXTENSION_VERSION_RE,
+  PLACEHOLDER_VERSION,
+  isValidExtensionVersion,
+  normalizeTag,
+  incrementVersion,
+} from "../scripts/lib/version.js";
+
+describe("isValidExtensionVersion", () => {
+  it("accepts 1–4 dot-separated integers (Chrome MV3)", () => {
+    for (const v of ["1", "1.0", "1.0.6", "1.0.6.65535"]) {
+      expect(isValidExtensionVersion(v)).toBe(true);
+    }
+  });
+
+  it("rejects prerelease, non-numeric, and malformed versions", () => {
+    for (const v of ["1.0.6-beta.1", "v1.0.6", "1.0.6.7.8", "nightly", "ios-1.0.6", "1..0", ""]) {
+      expect(isValidExtensionVersion(v)).toBe(false);
+    }
+  });
+
+  it("rejects non-strings", () => {
+    expect(isValidExtensionVersion(null)).toBe(false);
+    expect(isValidExtensionVersion(undefined)).toBe(false);
+    expect(isValidExtensionVersion(106)).toBe(false);
+  });
+
+  it("the placeholder is not itself a stray valid value we'd ship (it is valid shape but flagged elsewhere)", () => {
+    // 0.0.0 is a shape-valid version; the build/guard reject it by identity,
+    // not by shape. This documents that distinction.
+    expect(EXTENSION_VERSION_RE.test(PLACEHOLDER_VERSION)).toBe(true);
+  });
+});
+
+describe("normalizeTag", () => {
+  it("strips a leading v", () => {
+    expect(normalizeTag("v1.0.6")).toBe("1.0.6");
+    expect(normalizeTag("1.0.6")).toBe("1.0.6");
+  });
+
+  it("returns null for a prerelease tag that the glob would let through", () => {
+    // The git describe --match glob matches "v1.2.3-beta.1"; normalizeTag is
+    // the second gate that rejects it. This is the exact hole a prior bug had.
+    expect(normalizeTag("v1.2.3-beta.1")).toBeNull();
+  });
+
+  it("returns null for non-version tags and empty input", () => {
+    for (const t of ["ios-1.0.6", "nightly", "", null, undefined]) {
+      expect(normalizeTag(t)).toBeNull();
+    }
+  });
+});
+
+describe("incrementVersion", () => {
+  it("bumps the patch component", () => {
+    expect(incrementVersion("1.0.6")).toBe("1.0.7");
+    expect(incrementVersion("0.0.0")).toBe("0.0.1");
+    expect(incrementVersion("1.2.9")).toBe("1.2.10");
+  });
+
+  it("preserves leading components", () => {
+    expect(incrementVersion("2.5.0")).toBe("2.5.1");
+  });
+
+  it("throws on fewer than three components", () => {
+    expect(() => incrementVersion("1.0")).toThrow(/Expected semver/);
+  });
+
+  it("throws when the patch component is not numeric", () => {
+    expect(() => incrementVersion("1.0.x")).toThrow(/Invalid patch version/);
+  });
+});


### PR DESCRIPTION
## Problem

The extension version had multiple independent sources that drifted apart:

| Source | Was |
|--------|-----|
| `src/manifest*.json` → `dist/*/manifest.json` (popup shows this) | `0.3.7` |
| Xcode `MARKETING_VERSION` (what Apple/App Store sees) | `1.0.6` |
| latest git release tag | `1.0.5` |

Production builds copied the hardcoded `version` from the source manifests verbatim, so the Safari popup showed **v0.3.7** even though the iOS app was submitted to Apple as **1.0.6**. Chrome/Firefox only stayed correct because `release.yml` re-injects the tag via `jq`; any local production build drifted too. And Xcode `MARKETING_VERSION` was hand-edited, so it ran ahead of the git tag (1.0.6 vs 1.0.5).

## Change

Make the **git tag the single source of truth** for every version.

- **`scripts/lib/version.js`** (new) — one place for the tag rules: the `git describe` glob, the semver policy (`EXTENSION_VERSION_RE`, 1–4 integers per Chrome MV3), `getGitVersion` (glob + validation + memoized), `normalizeTag`, and `incrementVersion`. Both the build and the guard import it so the rules can't drift apart.
- **`esbuild.config.js`** — `resolveManifestVersion()` injects the version for every build (Chrome/Firefox/Safari): production uses the tag verbatim, dev/watch uses tag+1 as a preview. In production it **throws** rather than shipping the `0.0.0` placeholder or an invalid version (e.g. a prerelease tag) when no valid tag is reachable.
- **`src/manifest*.json`** — `version` set to the `0.0.0` placeholder (injected at build time; no longer hand-edited).
- **`scripts/set-safari-version.sh`** — sets Xcode `MARKETING_VERSION` from a version via `agvtool` (macOS only). Strips a leading `v` and validates on both paths before touching the tracked `project.pbxproj`. Its 3-part limit is a documented, deliberately-stricter divergence from the JS module (App Store ≤3 parts vs Chrome ≤4).
- **`scripts/check-versions.js`** — guard comparing the tag against `MARKETING_VERSION` and the built `dist/*/manifest.json`. Uses the shared `getGitVersion`, so a prerelease tag can't slip past by comparing an invalid version against itself. Flags a `0.0.0` placeholder even with no tag; strips quotes from `MARKETING_VERSION`; `--web` mode skips the Safari version for web-only releases.
- **`scripts/package.sh`** — cleans `dist/` first (no stale dirs), builds both outputs itself, and runs the guard (`--web`) **before** zipping so a mismatch can't leave a wrongly-named zip.
- **`.github/workflows/release.yml`** — `fetch-depth: 0` so the build reads the tag directly; jq-patches all four manifests (incl. `manifest.safari.json`); builds Firefox self-hosted after packaging (since `package.sh` now cleans `dist/`). A fail-fast step rejects a tag that isn't a plain `X.Y.Z` version (e.g. `v1.2` or a prerelease), which would otherwise resolve to the previous release's version.
- **Tests** — `test/version.test.js` covers `isValidExtensionVersion`, `normalizeTag` (incl. the prerelease hole), and `incrementVersion`'s error paths.
- **Docs** — `docs/SAFARI_WORKFLOW.md` gets a two-modes intro (develop/test vs release) and a release checklist that verifies locally **before** the irreversible tag push; `CLAUDE.md` Version Management rewritten around the git tag.

## Verification

```
$ npm run build          # with tag v1.0.6
📦 chrome: Prod build using git tag 1.0.6
📦 firefox: Prod build using git tag 1.0.6
📦 safari: Prod build using git tag 1.0.6

$ npm run check:versions
  git tag (source of truth)       1.0.6
  Xcode MARKETING_VERSION         1.0.6
  dist/chrome/manifest.json       1.0.6
  dist/firefox/manifest.json      1.0.6
  dist/firefox-amo/manifest.json  1.0.6
  dist/safari/manifest.json       1.0.6
✅ All present version sources match the git tag.

# no reachable tag, production build → throws instead of shipping 0.0.0:
$ GIT_DIR=/tmp/none NODE_ENV=production node esbuild.config.js
Build failed: Error: Cannot resolve a real version for "chrome": no semver git tag is reachable ...
```

`npm test` → 131 passing.

## Release flow

1. `npm run set:safari-version X.Y.Z` (sets `MARKETING_VERSION`)
2. commit `project.pbxproj`
3. `git tag vX.Y.Z` — local only
4. `npm run build && npm run check:versions` — verify before anything ships
5. `git push origin vX.Y.Z` — ships Chrome/Firefox (irreversible), done last
6. Xcode: Archive → App Store Connect

## Optional follow-up (not in this PR)

- An `EXT_VERSION` env override could let `release.yml` state the version to the build directly and collapse the `git describe` vs `jq` paths. Not required for correctness now — the fail-fast tag-shape check already stops the short/prerelease-tag case.
- `package.json`'s `version` is left out of the tag-driven flow on purpose — it's npm-local metadata, not read by the build and not shipped.
