### PR TITLE
chore(safari): bump MARKETING_VERSION to 1.0.7 + fix set:safari-version

### DIFF
--- a/dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj
+++ b/dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj
@@ -722,7 +722,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -755,7 +755,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -795,7 +795,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -836,7 +836,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -876,7 +876,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -912,7 +912,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -952,7 +952,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -995,7 +995,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 1.0.6;
+				MARKETING_VERSION = 1.0.7;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,

--- a/docs/SAFARI_WORKFLOW.md
+++ b/docs/SAFARI_WORKFLOW.md
@@ -89,7 +89,7 @@ Copy-paste checklist to ship version `X.Y.Z`:
 ```bash
 # 1. Set the Safari app version explicitly (no tag needed yet — this is what
 #    lets the version bump be committed BEFORE the tag exists).
-npm run set:safari-version X.Y.Z   # sets Xcode MARKETING_VERSION (agvtool)
+npm run set:safari-version X.Y.Z   # writes MARKETING_VERSION into project.pbxproj (no Xcode needed)
 
 # 2. Commit the bump so the tag (next step) points at a commit that has it.
 #    project.pbxproj IS tracked in git.
@@ -127,10 +127,18 @@ local tag (`git tag -d vX.Y.Z`) before it's pushed.
 | App `MARKETING_VERSION` | App Store Connect / Apple | `npm run set:safari-version` |
 
 **Re-uploading the same version?** App Store Connect rejects a duplicate build
-number. Bump only the build number (not the version) with:
+number. Bump only the build number (`CURRENT_PROJECT_VERSION`), not the version.
+It lives in `project.pbxproj` alongside `MARKETING_VERSION` — edit it directly.
+(Don't reach for `agvtool next-version`: this project sets no
+`VERSIONING_SYSTEM = APPLE_GENERIC` and the Info.plists carry no `CFBundleVersion`
+key, so agvtool writes nothing and reports success anyway — the same silent no-op
+that once left `MARKETING_VERSION` stale.)
 
 ```bash
-( cd "dist-safari/safari-project/Lee-Su-Sui" && xcrun agvtool next-version -all )
+PBXPROJ="dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj"
+# Pick the next integer (they're all in sync — currently 1, so use 2, etc.):
+perl -i -pe 's/CURRENT_PROJECT_VERSION = [^;]*;/CURRENT_PROJECT_VERSION = 2;/g' "$PBXPROJ"
+grep -c 'CURRENT_PROJECT_VERSION = 2;' "$PBXPROJ"   # expect 8 — one per build config
 ```
 
 ## Commands Reference

--- a/docs/SAFARI_WORKFLOW.md
+++ b/docs/SAFARI_WORKFLOW.md
@@ -136,9 +136,9 @@ that once left `MARKETING_VERSION` stale.)
 
 ```bash
 PBXPROJ="dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj"
-# Pick the next integer (they're all in sync — currently 1, so use 2, etc.):
-perl -i -pe 's/CURRENT_PROJECT_VERSION = [^;]*;/CURRENT_PROJECT_VERSION = 2;/g' "$PBXPROJ"
-grep -c 'CURRENT_PROJECT_VERSION = 2;' "$PBXPROJ"   # expect 8 — one per build config
+BUILD=2   # next integer; they're all in sync (currently 1)
+perl -i -pe "s/CURRENT_PROJECT_VERSION\s*=\s*[^;]*;/CURRENT_PROJECT_VERSION = ${BUILD};/g" "$PBXPROJ"
+grep -Fc "CURRENT_PROJECT_VERSION = ${BUILD};" "$PBXPROJ"   # expect 8 — one per build config
 ```
 
 ## Commands Reference
@@ -186,9 +186,12 @@ npm run open:safari
 # Reconfigure signing for each target
 ```
 > ⚠️ `npm run setup:safari` runs the converter with `--force` and regenerates
-> `project.pbxproj` wholesale, resetting `MARKETING_VERSION` (and signing). After
-> re-running it, re-apply the version with `npm run set:safari-version X.Y.Z`
-> before archiving.
+> `project.pbxproj` wholesale, resetting `MARKETING_VERSION`, `CURRENT_PROJECT_VERSION`
+> (the build number, back to `1`), and signing. After re-running it, re-apply the
+> version with `npm run set:safari-version X.Y.Z` before archiving — and if you'd
+> already bumped the build number for a re-upload, re-apply that too (see the
+> `CURRENT_PROJECT_VERSION` snippet above), or App Store Connect will reject the
+> reused build `1`.
 
 **Q: Want to test production build**
 ```bash

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -60,7 +60,9 @@ function getMarketingVersions() {
   );
   if (!existsSync(pbxproj)) return null;
   const content = readFileSync(pbxproj, "utf-8");
-  const versions = [...content.matchAll(/MARKETING_VERSION = ([^;]+);/g)].map((m) =>
+  // \s*=\s* tolerates any spacing — a hand-edited MARKETING_VERSION=1.0.6;
+  // (no spaces) must not slip past the release guard.
+  const versions = [...content.matchAll(/MARKETING_VERSION\s*=\s*([^;]+);/g)].map((m) =>
     // pbxproj values may be quoted (MARKETING_VERSION = "1.0.6";) — strip them.
     m[1].trim().replace(/^"|"$/g, ""),
   );

--- a/scripts/set-safari-version.sh
+++ b/scripts/set-safari-version.sh
@@ -66,22 +66,28 @@ fi
 
 echo "🍎 Setting Safari MARKETING_VERSION → $VERSION"
 
-# Rewrite every build config's MARKETING_VERSION. The value may be bare
-# (MARKETING_VERSION = 1.0.6;) or quoted (MARKETING_VERSION = "1.0.6";);
-# [^;]* covers both, and we always write it bare (a plain numeric version
-# needs no quoting).
-BEFORE="$(grep -c 'MARKETING_VERSION = ' "$PBXPROJ" || true)"
+# Count every MARKETING_VERSION entry, tolerating any spacing around '='.
+BEFORE="$(grep -Ec 'MARKETING_VERSION[[:space:]]*=' "$PBXPROJ" || true)"
 if [ "${BEFORE:-0}" -eq 0 ]; then
   echo "❌ No MARKETING_VERSION entries found in project.pbxproj — nothing to set." >&2
   exit 1
 fi
 
-perl -i -pe "s/MARKETING_VERSION = [^;]*;/MARKETING_VERSION = ${VERSION};/g" "$PBXPROJ"
+# Rewrite the value of every entry. Tolerates any spacing and an optionally
+# quoted old value (MARKETING_VERSION = "1.0.6";); always writes it bare, since
+# a plain numeric version needs no quoting.
+perl -i -pe "s/MARKETING_VERSION\s*=\s*[^;]*;/MARKETING_VERSION = ${VERSION};/g" "$PBXPROJ"
 
-UPDATED="$(grep -c "MARKETING_VERSION = ${VERSION};" "$PBXPROJ" || true)"
-if [ "${UPDATED:-0}" -ne "${BEFORE}" ]; then
-  echo "❌ Expected to set ${BEFORE} MARKETING_VERSION entries but only ${UPDATED} now read ${VERSION}." >&2
+# Verify by VALUE, not by count: every entry must now read exactly $VERSION.
+# The dots are escaped so it's a literal compare (not a regex wildcard), and
+# spacing/quotes are tolerated — so an oddly-spaced entry the rewrite missed is
+# caught here instead of passing silently (the very failure mode this script
+# exists to prevent).
+ESCAPED_VERSION="${VERSION//./\\.}"
+GOOD="$(grep -Ec "MARKETING_VERSION[[:space:]]*=[[:space:]]*\"?${ESCAPED_VERSION}\"?;" "$PBXPROJ" || true)"
+if [ "${GOOD:-0}" -ne "${BEFORE}" ]; then
+  echo "❌ Expected all ${BEFORE} MARKETING_VERSION entries to read ${VERSION}, but only ${GOOD} do." >&2
   exit 1
 fi
 
-echo "✅ Done (${UPDATED} MARKETING_VERSION ent(ies) now = ${VERSION})."
+echo "✅ Done (${GOOD} MARKETING_VERSION entries now = ${VERSION})."

--- a/scripts/set-safari-version.sh
+++ b/scripts/set-safari-version.sh
@@ -3,9 +3,17 @@ set -euo pipefail
 
 # Set the Safari/iOS app's Xcode MARKETING_VERSION from the latest git tag.
 #
-# macOS + Xcode only (uses `agvtool`). Run this before archiving the Safari
-# app for App Store submission so the App Store version always matches the
-# git tag — never hand-edit MARKETING_VERSION in project.pbxproj again.
+# Run this before archiving the Safari app for App Store submission so the
+# App Store version always matches the git tag — never hand-edit
+# MARKETING_VERSION in project.pbxproj by hand.
+#
+# The Xcode project uses GENERATE_INFOPLIST_FILE = YES, so the App Store
+# version (CFBundleShortVersionString) is derived from the MARKETING_VERSION
+# build setting in project.pbxproj — the Info.plist files carry no version
+# key of their own. That's why this writes MARKETING_VERSION in the pbxproj
+# directly. (An earlier version used `agvtool new-marketing-version`, which
+# only rewrites CFBundleShortVersionString in Info.plist — a no-op here, since
+# those files have no such key — so it silently failed to change the version.)
 #
 # Because project.pbxproj is tracked in git, the commit that sets the version
 # must exist *before* the tag points at it. The reliable release order is:
@@ -21,16 +29,11 @@ set -euo pipefail
 #   bash scripts/set-safari-version.sh          # re-sync from the latest git tag
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-XCODE_DIR="$PROJECT_ROOT/dist-safari/safari-project/Lee-Su-Sui"
+PBXPROJ="$PROJECT_ROOT/dist-safari/safari-project/Lee-Su-Sui/Lee-Su-Sui.xcodeproj/project.pbxproj"
 
-if ! command -v xcrun >/dev/null 2>&1 || ! xcrun --find agvtool >/dev/null 2>&1; then
-  echo "❌ agvtool not available. This script requires macOS with Xcode installed." >&2
-  exit 1
-fi
-
-if [ ! -d "$XCODE_DIR" ]; then
+if [ ! -f "$PBXPROJ" ]; then
   echo "❌ Xcode project not found at:" >&2
-  echo "   $XCODE_DIR" >&2
+  echo "   $PBXPROJ" >&2
   echo "   Run 'npm run setup:safari' first to generate it." >&2
   exit 1
 fi
@@ -62,7 +65,23 @@ if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+(\.[0-9]+){1,2}$'; then
 fi
 
 echo "🍎 Setting Safari MARKETING_VERSION → $VERSION"
-( cd "$XCODE_DIR" && xcrun agvtool new-marketing-version "$VERSION" >/dev/null )
 
-CURRENT="$( cd "$XCODE_DIR" && xcrun agvtool what-marketing-version -terse1 2>/dev/null | tail -n 1 || true )"
-echo "✅ Done (MARKETING_VERSION is now ${CURRENT:-$VERSION})."
+# Rewrite every build config's MARKETING_VERSION. The value may be bare
+# (MARKETING_VERSION = 1.0.6;) or quoted (MARKETING_VERSION = "1.0.6";);
+# [^;]* covers both, and we always write it bare (a plain numeric version
+# needs no quoting).
+BEFORE="$(grep -c 'MARKETING_VERSION = ' "$PBXPROJ" || true)"
+if [ "${BEFORE:-0}" -eq 0 ]; then
+  echo "❌ No MARKETING_VERSION entries found in project.pbxproj — nothing to set." >&2
+  exit 1
+fi
+
+perl -i -pe "s/MARKETING_VERSION = [^;]*;/MARKETING_VERSION = ${VERSION};/g" "$PBXPROJ"
+
+UPDATED="$(grep -c "MARKETING_VERSION = ${VERSION};" "$PBXPROJ" || true)"
+if [ "${UPDATED:-0}" -ne "${BEFORE}" ]; then
+  echo "❌ Expected to set ${BEFORE} MARKETING_VERSION entries but only ${UPDATED} now read ${VERSION}." >&2
+  exit 1
+fi
+
+echo "✅ Done (${UPDATED} MARKETING_VERSION ent(ies) now = ${VERSION})."


### PR DESCRIPTION
## What & why

Two related changes from cutting the **v1.0.7** Safari/iOS App Store release:

1. **Bump `MARKETING_VERSION` → 1.0.7** so `main`'s Xcode project matches the git tag `v1.0.7` and the build that was just archived + submitted for App Store review. Without this, `main` stays at 1.0.6 and the next release drifts.
2. **Fix `scripts/set-safari-version.sh`** — the sanctioned "never hand-edit the version" tool was a silent no-op on this project, which is why every past bump (1.0.5→1.0.6, and this one) had to hand-edit `project.pbxproj`.

## Root cause of the script bug

The Xcode project uses `GENERATE_INFOPLIST_FILE = YES`, so the App Store version (`CFBundleShortVersionString`) is derived from the `MARKETING_VERSION` **build setting** in `project.pbxproj` — the `Info.plist` files carry no version key of their own.

The old script used `agvtool new-marketing-version`, which only rewrites `CFBundleShortVersionString` in `Info.plist`. On this project that key doesn't exist, so agvtool:
- changed nothing in `project.pbxproj` (where the version actually lives),
- emitted a spurious `Cannot find "Lee-Su-Sui.xcodeproj/../YES"`,
- yet still printed `✅ Done` — a false success.

`npm run check:versions` reads `MARKETING_VERSION` from the pbxproj, so it correctly flagged the mismatch, but the "fix" it suggested (`set:safari-version`) couldn't resolve it.

## Change

The script now writes `MARKETING_VERSION` in `project.pbxproj` directly, then verifies **by value** — asserting every entry now reads exactly `$VERSION`, with dots escaped (literal compare) and whitespace/optional quotes tolerated, so an oddly-spaced entry the rewrite missed fails loudly instead of passing silently:

```
# before: agvtool → touches Info.plist (no-op here), false success
xcrun agvtool new-marketing-version "$VERSION"

# after: edit the setting that actually drives the version (any spacing / quotes)...
perl -i -pe "s/MARKETING_VERSION\s*=\s*[^;]*;/MARKETING_VERSION = ${VERSION};/g" "$PBXPROJ"
# ...then assert every entry now reads exactly $VERSION (dots escaped), else exit 1
```

Also drops the agvtool/Xcode dependency, so the script now runs on Linux/CI too. All existing guards (explicit arg or latest tag, `v` stripping, ≤3-part numeric for App Store) are unchanged.

## Also: guard hardening + docs

- **`scripts/check-versions.js`** matched `MARKETING_VERSION` with exact ` = ` spacing, so a hand-edited no-space `MARKETING_VERSION=1.0.6;` entry was invisible to the release guard — the other 7 configs would agree and it'd pass green while one config shipped stale (the same blind spot this PR closes in the setter). Matches with `\s*=\s*` now.
- **`docs/SAFARI_WORKFLOW.md`**'s duplicate-build-number recovery step used `agvtool next-version -all`, which has the **identical** false-success bug (no `VERSIONING_SYSTEM = APPLE_GENERIC`, no `CFBundleVersion` in the Info.plists; the build number is `CURRENT_PROJECT_VERSION` in the pbxproj — 8 entries, all `= 1`). Replaced with a direct `perl` edit (parameterized by a `BUILD=` variable, `\s*`-tolerant) + a verify line, corrected the stale `(agvtool)` attribution on the `set:safari-version` line, and noted that `setup:safari`'s `--force` regen also resets `CURRENT_PROJECT_VERSION` to `1`.

## Test plan

- `bash scripts/set-safari-version.sh 1.0.7` → all 8 build configs set to 1.0.7; re-runnable (idempotent).
- Verification tested against three fixtures: normal run, a quoted `"1.0.6"` value (normalized to bare), and a no-space `MARKETING_VERSION=1.0.6;` entry (previously the false-success case — now correctly rewritten and caught by the value check).
- No-arg form reads the latest tag (`v1.0.7`) correctly.
- Invalid input `1.2.3.4` is rejected with a clear error.
- Doc snippet's `perl CURRENT_PROJECT_VERSION` edit dry-run on a copy → all 8 entries bumped; real pbxproj left untouched.
- `npm run check:versions` → all present version sources match the git tag.
- Archived `Lee-Su-Sui (iOS) 1.0.7 (1)` in Xcode, validated, uploaded, and submitted for review — confirms the pbxproj version is what Xcode actually builds.

## Note

`MARKETING_VERSION` was still hand-edited *this* time (the bump commit predates the fixed script), matching how 1.0.6 was done. From the next release on, `npm run set:safari-version X.Y.Z` will do it correctly.

